### PR TITLE
docs: document Tomorrow.io provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ An awesome TypeScript weather client for fetching weather data from various weat
 - **Multiple Weather Providers with Fallback Support**: Seamlessly switch between weather providers and specify an ordered list for fallback.
   - [National Weather Service](https://weather-gov.github.io/api/)
   - [OpenWeather](https://openweathermap.org/api)
-  - [Tomorrow.io](https://www.tomorrow.io/) (coming soon!)
+  - [Tomorrow.io](https://www.tomorrow.io/)
   - [WeatherKit](https://developer.apple.com/weatherkit/) (coming soon!)
 - **Clean and Standardized API**: Fetch weather data using a consistent interface, regardless of the underlying provider.
   - Standardized weather conditions across providers
@@ -102,7 +102,8 @@ One of the main benefits of this library is the ability to seamlessly switch bet
     - Rate-limited to 5 requests per second and 300 requests per minute.
 - 'openweather' - OpenWeather
   - Requires an API key.
-- 'tomorrow.io' - Tomorrow.io (coming soon!)
+- 'tomorrow' - Tomorrow.io
+  - Requires an API key (create one at [app.tomorrow.io](https://app.tomorrow.io/)).
 - 'weatherkit' - Apple WeatherKit (coming soon!)
 
 ### Specifying Providers
@@ -111,9 +112,10 @@ You can specify the providers in order of preference:
 
 ```ts
 const weatherPlus = new WeatherPlus({
-  providers: ['nws', 'openweather'],
+  providers: ['nws', 'openweather', 'tomorrow'],
   apiKeys: {
     openweather: 'your-openweather-api-key',
+    tomorrow: 'your-tomorrow-io-api-key',
   },
 });
 ```
@@ -124,12 +126,31 @@ Some providers require API keys. Provide them using the apiKeys object, mapping 
 
 ```ts
 const weatherPlus = new WeatherPlus({
-  providers: ['openweather'],
+  providers: ['openweather', 'tomorrow'],
   apiKeys: {
     openweather: 'your-openweather-api-key',
+    tomorrow: 'your-tomorrow-io-api-key', // https://app.tomorrow.io/
   },
 });
 ```
+
+#### Tomorrow.io Configuration
+
+1. Sign up at [app.tomorrow.io](https://app.tomorrow.io/) and create an API key.
+2. Add the key to the `apiKeys` map under the `tomorrow` entry.
+3. Include `'tomorrow'` in the `providers` array (its position controls fallback order).
+
+```ts
+const weatherPlus = new WeatherPlus({
+  providers: ['tomorrow', 'openweather'],
+  apiKeys: {
+    tomorrow: process.env.TOMORROW_API_KEY!,
+    openweather: process.env.OPENWEATHER_API_KEY!,
+  },
+});
+```
+
+The Tomorrow adapter maps the realtime API to the shared schema, normalizing weather codes to `StandardWeatherCondition` and exposing temperature, humidity, dew point, and cloud cover values.
 
 ### Built-in Caching
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weather-plus",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Weather Plus is a powerful wrapper around various Weather APIs that simplifies adding weather data to your application",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",


### PR DESCRIPTION
## Summary
- remove outdated "coming soon" references for Tomorrow.io
- show provider ordering and apiKeys examples that include the new provider
- add configuration guidance for obtaining the Tomorrow.io key and what data is exposed

## Testing
- yarn lint