### PR TITLE
feat: add Weatherbit provider

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Project Structure & Module Organization
 - `src/` houses all TypeScript source; entry point is `src/index.ts`, with domain logic in `weatherService.ts` and provider implementations under `src/providers/`.
-- Each provider keeps its own helpers (`openweather/`, `nws/`, `tomorrow/`) and colocated tests (`*.test.ts`). Shared contracts live in `interfaces.ts` and `providers/IWeatherProvider.ts`.
+- Each provider keeps its own helpers (`openweather/`, `nws/`, `tomorrow/`, `weatherbit/`) and colocated tests (`*.test.ts`). Shared contracts live in `interfaces.ts` and `providers/IWeatherProvider.ts`.
 - Utilities (caching, error taxonomy, normalization) sit in `src/utils/` and `src/errors.ts`. Build artifacts publish to `dist/` (CJS and ESM). Architectural notes and RFCs reside in `docs/rfcs/`.
 
 ## Build, Test, and Development Commands

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ An awesome TypeScript weather client for fetching weather data from various weat
   - [National Weather Service](https://weather-gov.github.io/api/)
   - [OpenWeather](https://openweathermap.org/api)
   - [Tomorrow.io](https://www.tomorrow.io/)
+  - [Weatherbit](https://www.weatherbit.io/)
   - [WeatherKit](https://developer.apple.com/weatherkit/) (coming soon!)
 - **Clean and Standardized API**: Fetch weather data using a consistent interface, regardless of the underlying provider.
   - Standardized weather conditions across providers
@@ -104,6 +105,8 @@ One of the main benefits of this library is the ability to seamlessly switch bet
   - Requires an API key.
 - 'tomorrow' - Tomorrow.io
   - Requires an API key (create one at [app.tomorrow.io](https://app.tomorrow.io/)).
+- 'weatherbit' - Weatherbit
+  - Requires an API key (plans available directly from [weatherbit.io](https://www.weatherbit.io/)).
 - 'weatherkit' - Apple WeatherKit (coming soon!)
 
 ### Specifying Providers
@@ -112,10 +115,10 @@ You can specify the providers in order of preference:
 
 ```ts
 const weatherPlus = new WeatherPlus({
-  providers: ['nws', 'openweather', 'tomorrow'],
+  providers: ['nws', 'openweather', 'weatherbit'],
   apiKeys: {
     openweather: 'your-openweather-api-key',
-    tomorrow: 'your-tomorrow-io-api-key',
+    weatherbit: 'your-weatherbit-api-key',
   },
 });
 ```
@@ -126,10 +129,11 @@ Some providers require API keys. Provide them using the apiKeys object, mapping 
 
 ```ts
 const weatherPlus = new WeatherPlus({
-  providers: ['openweather', 'tomorrow'],
+  providers: ['openweather', 'tomorrow', 'weatherbit'],
   apiKeys: {
     openweather: 'your-openweather-api-key',
     tomorrow: 'your-tomorrow-io-api-key', // https://app.tomorrow.io/
+    weatherbit: 'your-weatherbit-api-key', // https://www.weatherbit.io/
   },
 });
 ```
@@ -151,6 +155,23 @@ const weatherPlus = new WeatherPlus({
 ```
 
 The Tomorrow adapter maps the realtime API to the shared schema, normalizing weather codes to `StandardWeatherCondition` and exposing temperature, humidity, dew point, and cloud cover values.
+
+#### Weatherbit Configuration
+
+1. Create an account at [weatherbit.io](https://www.weatherbit.io/) and generate an API key.
+2. Add the key to the `apiKeys` map under the `weatherbit` entry.
+3. Include `'weatherbit'` in your providers list wherever you want it to participate in the fallback order.
+
+```ts
+const weatherPlus = new WeatherPlus({
+  providers: ['weatherbit', 'nws'],
+  apiKeys: {
+    weatherbit: process.env.WEATHERBIT_API_KEY!,
+  },
+});
+```
+
+The Weatherbit adapter standardizes the realtime endpoint by mapping temperature, humidity, dew point, cloud cover, and the Weatherbit condition codes into the shared schema.
 
 ### Built-in Caching
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weather-plus",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Weather Plus is a powerful wrapper around various Weather APIs that simplifies adding weather data to your application",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",

--- a/src/providers/capabilities.test.ts
+++ b/src/providers/capabilities.test.ts
@@ -2,6 +2,7 @@ import { OPENWEATHER_CAPABILITY } from './openweather/client';
 import { NWS_CAPABILITY } from './nws/client';
 import { ProviderCapability } from './capabilities';
 import { TOMORROW_CAPABILITY } from './tomorrow/client';
+import { WEATHERBIT_CAPABILITY } from './weatherbit/client';
 
 describe('provider capabilities', () => {
   it('NWS_CAPABILITY matches expected shape and values', () => {
@@ -30,11 +31,20 @@ describe('provider capabilities', () => {
     expect(cap.supports.alerts).toBeFalsy();
   });
 
+  it('WEATHERBIT_CAPABILITY matches expected shape and values', () => {
+    const cap: ProviderCapability = WEATHERBIT_CAPABILITY;
+    expect(cap.supports.current).toBe(true);
+    expect(cap.supports.hourly).toBeFalsy();
+    expect(cap.supports.daily).toBeFalsy();
+    expect(cap.supports.alerts).toBeFalsy();
+  });
+
   it('validates the built-in capabilities map explicitly', () => {
     const map = {
       nws: NWS_CAPABILITY,
       openweather: OPENWEATHER_CAPABILITY,
       tomorrow: TOMORROW_CAPABILITY,
+      weatherbit: WEATHERBIT_CAPABILITY,
     } as const;
     expect(map).toEqual({
       nws: {
@@ -47,6 +57,10 @@ describe('provider capabilities', () => {
         locales: [],
       },
       tomorrow: {
+        supports: { current: true, hourly: false, daily: false, alerts: false },
+        regions: [],
+      },
+      weatherbit: {
         supports: { current: true, hourly: false, daily: false, alerts: false },
         regions: [],
       },

--- a/src/providers/capabilities.ts
+++ b/src/providers/capabilities.ts
@@ -1,4 +1,4 @@
-export type ProviderId = 'nws' | 'openweather' | 'tomorrow' | (string & {});
+export type ProviderId = 'nws' | 'openweather' | 'tomorrow' | 'weatherbit' | (string & {});
 
 export interface ProviderCapability {
   supports: {

--- a/src/providers/capabilitiesMap.ts
+++ b/src/providers/capabilitiesMap.ts
@@ -1,6 +1,7 @@
 import { OPENWEATHER_CAPABILITY } from './openweather/client';
 import { NWS_CAPABILITY } from './nws/client';
 import { TOMORROW_CAPABILITY } from './tomorrow/client';
+import { WEATHERBIT_CAPABILITY } from './weatherbit/client';
 import { ProviderCapability } from './capabilities';
 
 export function getBuiltInCapabilities(): Record<string, ProviderCapability> {
@@ -8,5 +9,6 @@ export function getBuiltInCapabilities(): Record<string, ProviderCapability> {
     nws: NWS_CAPABILITY,
     openweather: OPENWEATHER_CAPABILITY,
     tomorrow: TOMORROW_CAPABILITY,
+    weatherbit: WEATHERBIT_CAPABILITY,
   } as const;
 }

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -2,5 +2,6 @@ export { IWeatherProvider } from './IWeatherProvider';
 export { NWSProvider } from './nws/client';
 export { OpenWeatherProvider } from './openweather/client';
 export { TomorrowProvider } from './tomorrow/client';
+export { WeatherbitProvider } from './weatherbit/client';
 export * from './capabilities';
 export { defaultOutcomeReporter, NoopProviderOutcomeReporter, ProviderOutcomeReporter } from './outcomeReporter';

--- a/src/providers/providerFactory.test.ts
+++ b/src/providers/providerFactory.test.ts
@@ -1,6 +1,7 @@
 import { ProviderFactory } from './providerFactory';
 import { ProviderNotSupportedError } from '../errors';
 import { TomorrowProvider } from './tomorrow/client';
+import { WeatherbitProvider } from './weatherbit/client';
 
 describe('ProviderFactory', () => {
   it('should throw ProviderNotSupportedError for unsupported providers', () => {
@@ -13,5 +14,11 @@ describe('ProviderFactory', () => {
     const provider = ProviderFactory.createProvider('tomorrow', 'api-key');
     expect(provider).toBeInstanceOf(TomorrowProvider);
     expect(provider.name).toBe('tomorrow');
+  });
+
+  it('creates a WeatherbitProvider when requested', () => {
+    const provider = ProviderFactory.createProvider('weatherbit', 'api-key');
+    expect(provider).toBeInstanceOf(WeatherbitProvider);
+    expect(provider.name).toBe('weatherbit');
   });
 });

--- a/src/providers/providerFactory.ts
+++ b/src/providers/providerFactory.ts
@@ -2,6 +2,7 @@ import { IWeatherProvider } from './IWeatherProvider';
 import { NWSProvider } from './nws/client';
 import { OpenWeatherProvider } from './openweather/client';
 import { TomorrowProvider } from './tomorrow/client';
+import { WeatherbitProvider } from './weatherbit/client';
 import { ProviderNotSupportedError } from '../errors';
 import { ProviderId } from './capabilities';
 
@@ -14,6 +15,8 @@ export const ProviderFactory = {
         return new OpenWeatherProvider(apiKey ?? '');
       case 'tomorrow':
         return new TomorrowProvider(apiKey ?? '');
+      case 'weatherbit':
+        return new WeatherbitProvider(apiKey ?? '');
       default:
         throw new ProviderNotSupportedError(
           `Provider ${providerName} is not supported yet`

--- a/src/providers/weatherbit/client.test.ts
+++ b/src/providers/weatherbit/client.test.ts
@@ -165,4 +165,25 @@ describe('WeatherbitProvider', () => {
     spy.mockRestore();
     mock = new MockAdapter(axios);
   });
+
+  it('swallows reporter failures while reporting upstream errors', async () => {
+    const failingReporter: ProviderOutcomeReporter = {
+      record() {
+        throw new Error('reporting failure');
+      },
+    };
+
+    const original = defaultOutcomeReporter;
+    setDefaultOutcomeReporter(failingReporter);
+
+    mock
+      .onGet('https://api.weatherbit.io/v2.0/current')
+      .reply(503);
+
+    try {
+      await expect(provider.getWeather(lat, lng)).rejects.toThrow('Request failed with status code 503');
+    } finally {
+      setDefaultOutcomeReporter(original);
+    }
+  });
 });

--- a/src/providers/weatherbit/client.test.ts
+++ b/src/providers/weatherbit/client.test.ts
@@ -136,6 +136,26 @@ describe('WeatherbitProvider', () => {
     });
   });
 
+  it('omits optional metrics when Weatherbit leaves them undefined', async () => {
+    mock
+      .onGet('https://api.weatherbit.io/v2.0/current')
+      .reply(200, {
+        data: [
+          {
+            temp: 18,
+            weather: { code: 1000, description: 'Clear sky' },
+          },
+        ],
+      });
+
+    const data = await provider.getWeather(lat, lng);
+
+    expect(data).toEqual({
+      temperature: { value: 18, unit: 'C' },
+      conditions: { value: 'Clear', unit: 'string', original: 'Clear sky' },
+    });
+  });
+
   it('wraps unexpected rejection payloads', async () => {
     mock.restore();
     const spy = jest.spyOn(axios, 'get').mockRejectedValueOnce(undefined);

--- a/src/providers/weatherbit/client.test.ts
+++ b/src/providers/weatherbit/client.test.ts
@@ -1,0 +1,148 @@
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+import { WeatherbitProvider } from './client';
+import { ProviderOutcomeReporter } from '../outcomeReporter';
+import { defaultOutcomeReporter, setDefaultOutcomeReporter } from '../outcomeReporter';
+import { ProviderCallOutcome } from '../capabilities';
+
+describe('WeatherbitProvider', () => {
+  const lat = 43.6535;
+  const lng = -79.3839;
+  const apiKey = 'test-weatherbit-key';
+  let mock: MockAdapter;
+  let provider: WeatherbitProvider;
+
+  beforeEach(() => {
+    mock = new MockAdapter(axios);
+    provider = new WeatherbitProvider(apiKey);
+  });
+
+  afterEach(() => {
+    mock.restore();
+  });
+
+  it('throws if API key is missing', () => {
+    expect(() => new WeatherbitProvider('')).toThrow('Weatherbit provider requires an API key.');
+  });
+
+  it('converts Weatherbit current response into weather data', async () => {
+    const mockResponse = {
+      data: [
+        {
+          temp: 21.3,
+          rh: 56,
+          dewpt: 11.2,
+          clouds: 40,
+          weather: {
+            code: 1100,
+            description: 'Partly cloudy',
+          },
+        },
+      ],
+    };
+
+    mock
+      .onGet('https://api.weatherbit.io/v2.0/current', {
+        params: {
+          lat: lat.toString(),
+          lon: lng.toString(),
+          key: apiKey,
+        },
+      })
+      .reply(200, mockResponse);
+
+    const data = await provider.getWeather(lat, lng);
+
+    expect(data).toEqual({
+      temperature: { value: 21.3, unit: 'C' },
+      humidity: { value: 56, unit: 'percent' },
+      dewPoint: { value: 11.2, unit: 'C' },
+      cloudiness: { value: 40, unit: 'percent' },
+      conditions: { value: 'Partly Cloudy', unit: 'string', original: 'Partly cloudy' },
+    });
+  });
+
+  it('records failure metadata when Weatherbit responds with an error', async () => {
+    class TestReporter implements ProviderOutcomeReporter {
+      public events: Array<{ provider: string; outcome: ProviderCallOutcome }> = [];
+      record(provider: string, outcome: ProviderCallOutcome): void {
+        this.events.push({ provider, outcome });
+      }
+    }
+
+    const reporter = new TestReporter();
+    const original = defaultOutcomeReporter;
+    setDefaultOutcomeReporter(reporter);
+
+    mock
+      .onGet('https://api.weatherbit.io/v2.0/current')
+      .reply(429);
+
+    try {
+      await expect(provider.getWeather(lat, lng)).rejects.toThrow('Request failed with status code 429');
+      expect(reporter.events).toHaveLength(1);
+      expect(reporter.events[0]).toEqual({
+        provider: 'weatherbit',
+        outcome: expect.objectContaining({
+          ok: false,
+          code: 'UpstreamError',
+          status: 429,
+        }),
+      });
+    } finally {
+      setDefaultOutcomeReporter(original);
+    }
+  });
+
+  it('throws when response has no usable data', async () => {
+    mock
+      .onGet('https://api.weatherbit.io/v2.0/current')
+      .reply(200, { data: [] });
+
+    await expect(provider.getWeather(lat, lng)).rejects.toThrow('Invalid weather data');
+  });
+
+  it('throws when record lacks core temperature metrics', async () => {
+    mock
+      .onGet('https://api.weatherbit.io/v2.0/current')
+      .reply(200, {
+        data: [
+          {
+            weather: { code: 1000 },
+          },
+        ],
+      });
+
+    await expect(provider.getWeather(lat, lng)).rejects.toThrow('Invalid weather data');
+  });
+
+  it('handles unknown weather codes gracefully', async () => {
+    mock
+      .onGet('https://api.weatherbit.io/v2.0/current')
+      .reply(200, {
+        data: [
+          {
+            rh: 50,
+            weather: { code: 9999 },
+          },
+        ],
+      });
+
+    const data = await provider.getWeather(lat, lng);
+
+    expect(data).toEqual({
+      humidity: { value: 50, unit: 'percent' },
+      conditions: { value: 'Unknown', unit: 'string', original: 'Code 9999' },
+    });
+  });
+
+  it('wraps unexpected rejection payloads', async () => {
+    mock.restore();
+    const spy = jest.spyOn(axios, 'get').mockRejectedValueOnce(undefined);
+
+    await expect(provider.getWeather(lat, lng)).rejects.toThrow('Failed to fetch Weatherbit data');
+
+    spy.mockRestore();
+    mock = new MockAdapter(axios);
+  });
+});

--- a/src/providers/weatherbit/client.ts
+++ b/src/providers/weatherbit/client.ts
@@ -1,0 +1,114 @@
+import axios, { AxiosError } from 'axios';
+import debug from 'debug';
+import { IWeatherProvider } from '../IWeatherProvider';
+import { IWeatherProviderWeatherData, IWeatherUnits } from '../../interfaces';
+import { ProviderCapability } from '../capabilities';
+import { defaultOutcomeReporter } from '../outcomeReporter';
+import { describeWeatherbitCondition, standardizeWeatherbitCondition } from './condition';
+import { IWeatherbitCurrentResponse } from './interfaces';
+
+const log = debug('weather-plus:weatherbit:client');
+
+export const WEATHERBIT_CAPABILITY: ProviderCapability = Object.freeze({
+  supports: { current: true, hourly: false, daily: false, alerts: false },
+  regions: [],
+});
+
+export class WeatherbitProvider implements IWeatherProvider {
+  name = 'weatherbit';
+  private readonly apiKey: string;
+
+  constructor(apiKey: string) {
+    if (!apiKey) {
+      throw new Error('Weatherbit provider requires an API key.');
+    }
+    this.apiKey = apiKey;
+  }
+
+  public async getWeather(lat: number, lng: number): Promise<Partial<IWeatherProviderWeatherData>> {
+    const start = Date.now();
+    const url = 'https://api.weatherbit.io/v2.0/current';
+    const params = {
+      lat: lat.toString(),
+      lon: lng.toString(),
+      key: this.apiKey,
+    } as const;
+
+    log(`Fetching weather data from Weatherbit: ${url} with params ${JSON.stringify(params)}`);
+
+    try {
+      const response = await axios.get<IWeatherbitCurrentResponse>(url, { params });
+      const result = convertToWeatherData(response.data);
+      defaultOutcomeReporter.record('weatherbit', { ok: true, latencyMs: Date.now() - start });
+      return result;
+    } catch (error: unknown) {
+      log('Error in getWeather:', error);
+      try {
+        const axiosError = error as AxiosError | undefined;
+        defaultOutcomeReporter.record('weatherbit', {
+          ok: false,
+          latencyMs: Date.now() - start,
+          code: 'UpstreamError',
+          status: axiosError?.response?.status,
+        });
+      } catch {}
+      throw (error instanceof Error ? error : new Error('Failed to fetch Weatherbit data'));
+    }
+  }
+}
+
+function convertToWeatherData(payload: IWeatherbitCurrentResponse): Partial<IWeatherProviderWeatherData> {
+  const current = payload.data?.[0];
+  if (!current) {
+    throw new Error('Invalid weather data');
+  }
+
+  const { temp, rh, dewpt, clouds, weather } = current;
+
+  if (
+    typeof temp !== 'number' &&
+    typeof rh !== 'number' &&
+    typeof dewpt !== 'number'
+  ) {
+    throw new Error('Invalid weather data');
+  }
+
+  const result: Partial<IWeatherProviderWeatherData> = {};
+
+  if (typeof temp === 'number') {
+    result.temperature = {
+      value: temp,
+      unit: IWeatherUnits.C,
+    };
+  }
+
+  if (typeof rh === 'number') {
+    result.humidity = {
+      value: rh,
+      unit: IWeatherUnits.percent,
+    };
+  }
+
+  if (typeof dewpt === 'number') {
+    result.dewPoint = {
+      value: dewpt,
+      unit: IWeatherUnits.C,
+    };
+  }
+
+  if (typeof clouds === 'number') {
+    result.cloudiness = {
+      value: clouds,
+      unit: IWeatherUnits.percent,
+    };
+  }
+
+  const code = weather?.code;
+  result.conditions = {
+    value: standardizeWeatherbitCondition(code ?? -1),
+    unit: IWeatherUnits.string,
+    original: describeWeatherbitCondition(code, weather?.description),
+  };
+
+  return result;
+}

--- a/src/providers/weatherbit/condition.test.ts
+++ b/src/providers/weatherbit/condition.test.ts
@@ -11,6 +11,7 @@ describe('Weatherbit condition mapping', () => {
   });
 
   it('defaults to Unknown for unsupported codes', () => {
+    expect(standardizeWeatherbitCondition(undefined)).toBe(StandardWeatherCondition.Unknown);
     expect(standardizeWeatherbitCondition(9999)).toBe(StandardWeatherCondition.Unknown);
     expect(standardizeWeatherbitCondition(undefined)).toBe(StandardWeatherCondition.Unknown);
   });
@@ -19,5 +20,6 @@ describe('Weatherbit condition mapping', () => {
     expect(describeWeatherbitCondition(1100, 'Partly cloudy')).toBe('Partly cloudy');
     expect(describeWeatherbitCondition(9999)).toBe('Code 9999');
     expect(describeWeatherbitCondition(undefined, 'Custom')).toBe('Custom');
+    expect(describeWeatherbitCondition(undefined)).toBe('Unknown');
   });
 });

--- a/src/providers/weatherbit/condition.test.ts
+++ b/src/providers/weatherbit/condition.test.ts
@@ -3,6 +3,7 @@ import { StandardWeatherCondition } from '../../weatherCondition';
 
 describe('Weatherbit condition mapping', () => {
   it('maps known codes to standardized conditions', () => {
+    expect(standardizeWeatherbitCondition(800)).toBe(StandardWeatherCondition.Clear);
     expect(standardizeWeatherbitCondition(1000)).toBe(StandardWeatherCondition.Clear);
     expect(standardizeWeatherbitCondition(1101)).toBe(StandardWeatherCondition.MostlyCloudy);
     expect(standardizeWeatherbitCondition(4001)).toBe(StandardWeatherCondition.Rain);

--- a/src/providers/weatherbit/condition.test.ts
+++ b/src/providers/weatherbit/condition.test.ts
@@ -1,0 +1,22 @@
+import { describeWeatherbitCondition, standardizeWeatherbitCondition } from './condition';
+import { StandardWeatherCondition } from '../../weatherCondition';
+
+describe('Weatherbit condition mapping', () => {
+  it('maps known codes to standardized conditions', () => {
+    expect(standardizeWeatherbitCondition(1000)).toBe(StandardWeatherCondition.Clear);
+    expect(standardizeWeatherbitCondition(1101)).toBe(StandardWeatherCondition.MostlyCloudy);
+    expect(standardizeWeatherbitCondition(4001)).toBe(StandardWeatherCondition.Rain);
+    expect(standardizeWeatherbitCondition(8000)).toBe(StandardWeatherCondition.Thunderstorms);
+  });
+
+  it('defaults to Unknown for unsupported codes', () => {
+    expect(standardizeWeatherbitCondition(9999)).toBe(StandardWeatherCondition.Unknown);
+    expect(standardizeWeatherbitCondition(undefined)).toBe(StandardWeatherCondition.Unknown);
+  });
+
+  it('prefers provided descriptions when available', () => {
+    expect(describeWeatherbitCondition(1100, 'Partly cloudy')).toBe('Partly cloudy');
+    expect(describeWeatherbitCondition(9999)).toBe('Code 9999');
+    expect(describeWeatherbitCondition(undefined, 'Custom')).toBe('Custom');
+  });
+});

--- a/src/providers/weatherbit/condition.ts
+++ b/src/providers/weatherbit/condition.ts
@@ -1,6 +1,7 @@
 import { StandardWeatherCondition } from '../../weatherCondition';
 
 const WEATHERBIT_CODE_MAP: Record<number, StandardWeatherCondition> = {
+  800: StandardWeatherCondition.Clear,
   1000: StandardWeatherCondition.Clear,
   1001: StandardWeatherCondition.MostlyClear,
   1100: StandardWeatherCondition.PartlyCloudy,

--- a/src/providers/weatherbit/condition.ts
+++ b/src/providers/weatherbit/condition.ts
@@ -1,0 +1,58 @@
+import { StandardWeatherCondition } from '../../weatherCondition';
+
+const WEATHERBIT_CODE_MAP: Record<number, StandardWeatherCondition> = {
+  1000: StandardWeatherCondition.Clear,
+  1001: StandardWeatherCondition.MostlyClear,
+  1100: StandardWeatherCondition.PartlyCloudy,
+  1101: StandardWeatherCondition.MostlyCloudy,
+  1102: StandardWeatherCondition.Overcast,
+  2000: StandardWeatherCondition.Fog,
+  2100: StandardWeatherCondition.Mist,
+  2101: StandardWeatherCondition.Haze,
+  2200: StandardWeatherCondition.Smoke,
+  2300: StandardWeatherCondition.Dust,
+  3000: StandardWeatherCondition.Breezy,
+  3001: StandardWeatherCondition.Windy,
+  3002: StandardWeatherCondition.Windy,
+  4000: StandardWeatherCondition.LightRain,
+  4001: StandardWeatherCondition.Rain,
+  4002: StandardWeatherCondition.HeavyRain,
+  4200: StandardWeatherCondition.Showers,
+  4201: StandardWeatherCondition.Showers,
+  4202: StandardWeatherCondition.HeavyRain,
+  5000: StandardWeatherCondition.LightSnow,
+  5001: StandardWeatherCondition.Snow,
+  5002: StandardWeatherCondition.HeavySnow,
+  5100: StandardWeatherCondition.Sleet,
+  5101: StandardWeatherCondition.Sleet,
+  5102: StandardWeatherCondition.HeavySnow,
+  6000: StandardWeatherCondition.FreezingRain,
+  6001: StandardWeatherCondition.FreezingRain,
+  6002: StandardWeatherCondition.HeavyRain,
+  7000: StandardWeatherCondition.Sleet,
+  7001: StandardWeatherCondition.Sleet,
+  7002: StandardWeatherCondition.HeavySnow,
+  7101: StandardWeatherCondition.LightSnow,
+  7102: StandardWeatherCondition.Snow,
+  7200: StandardWeatherCondition.Mixed,
+  7201: StandardWeatherCondition.Mixed,
+  7202: StandardWeatherCondition.Mixed,
+  8000: StandardWeatherCondition.Thunderstorms,
+};
+
+export function standardizeWeatherbitCondition(code: number | undefined): StandardWeatherCondition {
+  if (typeof code !== 'number') {
+    return StandardWeatherCondition.Unknown;
+  }
+  return WEATHERBIT_CODE_MAP[code] ?? StandardWeatherCondition.Unknown;
+}
+
+export function describeWeatherbitCondition(code: number | undefined, description?: string): string {
+  if (typeof code !== 'number') {
+    return description ?? 'Unknown';
+  }
+  if (description) {
+    return description;
+  }
+  return `Code ${code}`;
+}

--- a/src/providers/weatherbit/interfaces.ts
+++ b/src/providers/weatherbit/interfaces.ts
@@ -1,0 +1,12 @@
+export interface IWeatherbitCurrentResponse {
+  data?: Array<{
+    temp?: number; // Temperature in Celsius
+    rh?: number; // Relative humidity %
+    dewpt?: number; // Dew point in Celsius
+    clouds?: number; // Cloud cover %
+    weather?: {
+      code?: number;
+      description?: string;
+    };
+  }>;
+}

--- a/src/weatherService.test.ts
+++ b/src/weatherService.test.ts
@@ -253,6 +253,14 @@ describe('WeatherService', () => {
     expect(() => {
       new WeatherService({ providers: ['openweather'] });
     }).toThrow('OpenWeather provider requires an API key.');
+
+    expect(() => {
+      new WeatherService({ providers: ['tomorrow'] });
+    }).toThrow('Tomorrow.io provider requires an API key.');
+
+    expect(() => {
+      new WeatherService({ providers: ['weatherbit'] });
+    }).toThrow('Weatherbit provider requires an API key.');
   });
 
   it('throws a descriptive error when no providers can supply data', async () => {

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -10,5 +10,5 @@
       "declaration": true,
       "resolveJsonModule": true
     },
-    "exclude": ["node_modules", "jest.config.ts"]
+    "exclude": ["node_modules", "jest.config.ts", "**/*.test.ts"]
   }

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -11,5 +11,5 @@
       "declaration": true,
       "resolveJsonModule": true
     },
-    "exclude": ["node_modules", "jest.config.ts"]
+    "exclude": ["node_modules", "jest.config.ts", "**/*.test.ts"]
   }


### PR DESCRIPTION
## Summary
- introduce Weatherbit provider with capability metadata and standardized condition mapping
- update factory, capabilities map, README docs, and exclude tests from build tsconfigs
- bump version to 1.4.0 and expand tests to maintain >97.5% coverage

## Testing
- yarn lint
- yarn coverage
- yarn build