### PR TITLE
docs: publish static docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![npm](https://img.shields.io/npm/v/weather-plus)](https://www.npmjs.com/package/weather-plus) [![Codecov](https://img.shields.io/codecov/c/github/texturehq/weather-plus)](https://codecov.io/gh/texturehq/weather-plus)
 
+📘 **Documentation:** [weather-plus.dev](https://weather-plus.dev)
+
 An awesome TypeScript weather client for fetching weather data from various weather providers.
 
 ## What Makes It "Plus"?

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+weather-plus.dev

--- a/docs/index.html
+++ b/docs/index.html
@@ -137,7 +137,9 @@
         <h1>Typed weather data from multiple providers, one API.</h1>
         <p>
           Weather Plus wraps NWS, OpenWeather, Tomorrow.io, and Weatherbit behind a
-          single, type-safe interface with built-in caching and graceful fallback.
+          single interface—normalizing wildly different payloads and condition codes
+          into one schema—so your application stays consistent even when
+          providers change.
         </p>
         <div class="hero-logo">
           <img
@@ -166,17 +168,28 @@
             </p>
           </article>
           <article class="feature-card">
-            <h3>Strict TypeScript types</h3>
+            <h3>Unified schema</h3>
             <p>
-              All responses conform to a shared schema with standardized weather
-              conditions to keep your domain logic predictable.
+              Weather Plus transforms each provider’s response into the same,
+              strictly-typed shape—temperature, humidity, cloud cover, and
+              standardized conditions included—so swapping providers or adding
+              fallbacks is trivial.
             </p>
           </article>
           <article class="feature-card">
             <h3>Smart caching</h3>
             <p>
-              Use an in-memory cache out of the box or plug in Redis for
-              multi-instance deployments. Geohash keys keep stores compact.
+              Use in-memory or Redis caching with geohash keys. Closely located
+              lookups map to the same cell, delivering high hit rates while keeping
+              the cache compact.
+            </p>
+          </article>
+          <article class="feature-card">
+            <h3>Reliable fallback</h3>
+            <p>
+              Weather Plus automatically records successes, failure reasons, retry
+              hints, and latency, favoring healthy providers and bubbling up issues
+              with enough context to debug quickly.
             </p>
           </article>
           <article class="feature-card">
@@ -276,7 +289,8 @@ console.log(report.conditions.value);
             <h3>Observability</h3>
             <p>
               Inject a custom outcome reporter to log or emit metrics whenever a
-              provider call succeeds or fails.
+              provider call succeeds or fails. Capture latency distribution and
+              failure taxonomy out of the box.
             </p>
           </article>
         </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,283 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Weather Plus &mdash; TypeScript Weather SDK</title>
+    <meta
+      name="description"
+      content="Weather Plus is a TypeScript SDK for fetching realtime weather data from multiple providers with graceful fallback, caching, and strict typing."
+    />
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/@picocss/pico@2.0.6/css/pico.min.css"
+    />
+    <style>
+      :root {
+        --brand: #2563eb;
+        --brand-soft: #eef2ff;
+      }
+
+      body {
+        background: #f8fafc;
+      }
+
+      header.hero {
+        margin-top: 3rem;
+        text-align: center;
+      }
+
+      header.hero h1 {
+        font-size: clamp(2.5rem, 4vw, 3.5rem);
+        margin-bottom: 0.5rem;
+      }
+
+      header.hero p {
+        font-size: 1.1rem;
+        color: #334155;
+      }
+
+      .cta-buttons {
+        margin-top: 1.5rem;
+        display: flex;
+        justify-content: center;
+        gap: 1rem;
+        flex-wrap: wrap;
+      }
+
+      .feature-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+        gap: 1.5rem;
+      }
+
+      .feature-card {
+        padding: 1.5rem;
+        border-radius: 1rem;
+        background: white;
+        border: 1px solid #e2e8f0;
+        box-shadow: 0 4px 12px rgba(15, 23, 42, 0.05);
+      }
+
+      section {
+        margin-top: 4rem;
+      }
+
+      h2 {
+        margin-bottom: 1rem;
+      }
+
+      pre {
+        background: #0f172a;
+        color: #e2e8f0;
+        padding: 1rem;
+        border-radius: 0.75rem;
+        overflow-x: auto;
+      }
+
+      table {
+        border-radius: 1rem;
+        overflow: hidden;
+        box-shadow: 0 2px 12px rgba(15, 23, 42, 0.06);
+      }
+
+      .tag {
+        display: inline-block;
+        font-size: 0.85rem;
+        background: var(--brand-soft);
+        color: var(--brand);
+        padding: 0.25rem 0.6rem;
+        border-radius: 999px;
+      }
+
+      footer {
+        margin: 4rem 0 2rem;
+        text-align: center;
+        color: #64748b;
+      }
+    </style>
+  </head>
+  <body>
+    <main class="container">
+      <header class="hero">
+        <p class="tag">Weather Plus</p>
+        <h1>Typed weather data from multiple providers, one API.</h1>
+        <p>
+          Weather Plus wraps NWS, OpenWeather, Tomorrow.io, and Weatherbit behind a
+          single, type-safe interface with built-in caching and graceful fallback.
+        </p>
+        <div class="cta-buttons">
+          <a class="contrast" href="https://www.npmjs.com/package/weather-plus"
+            >View on npm</a
+          >
+          <a class="secondary" href="https://github.com/TextureHQ/weather-plus"
+            >GitHub repository</a
+          >
+        </div>
+      </header>
+
+      <section>
+        <h2>Why Weather Plus?</h2>
+        <div class="feature-grid">
+          <article class="feature-card">
+            <h3>Multi-provider fallback</h3>
+            <p>
+              Supply an ordered list of providers. Weather Plus will try each one
+              in turn and stop as soon as a provider succeeds.
+            </p>
+          </article>
+          <article class="feature-card">
+            <h3>Strict TypeScript types</h3>
+            <p>
+              All responses conform to a shared schema with standardized weather
+              conditions to keep your domain logic predictable.
+            </p>
+          </article>
+          <article class="feature-card">
+            <h3>Smart caching</h3>
+            <p>
+              Use an in-memory cache out of the box or plug in Redis for
+              multi-instance deployments. Geohash keys keep stores compact.
+            </p>
+          </article>
+          <article class="feature-card">
+            <h3>Observability hooks</h3>
+            <p>
+              Outcome reporters track provider successes, failures, and latency so
+              you can route alerts or metrics wherever you like.
+            </p>
+          </article>
+        </div>
+      </section>
+
+      <section>
+        <h2>Quick start</h2>
+        <pre><code>yarn add weather-plus</code></pre>
+        <pre><code class="language-ts">import WeatherPlus from 'weather-plus';
+
+const weather = new WeatherPlus({
+  providers: ['weatherbit', 'openweather', 'nws'],
+  apiKeys: {
+    weatherbit: process.env.WEATHERBIT_API_KEY!,
+    openweather: process.env.OPENWEATHER_API_KEY!,
+  },
+});
+
+const report = await weather.getWeather(40.7128, -74.0060);
+console.log(report.conditions.value);
+</code></pre>
+      </section>
+
+      <section>
+        <h2>Provider coverage</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Provider</th>
+              <th>API key</th>
+              <th>Region</th>
+              <th>Notes</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>National Weather Service (NWS)</td>
+              <td>No</td>
+              <td>United States</td>
+              <td>Best-effort public data, rate-limited by API policy.</td>
+            </tr>
+            <tr>
+              <td>OpenWeather</td>
+              <td>Yes</td>
+              <td>Global</td>
+              <td>Supports both free and paid tiers.</td>
+            </tr>
+            <tr>
+              <td>Tomorrow.io</td>
+              <td>Yes</td>
+              <td>Global</td>
+              <td>Realtime conditions with rich metadata.</td>
+            </tr>
+            <tr>
+              <td>Weatherbit</td>
+              <td>Yes</td>
+              <td>Global</td>
+              <td>Straightforward paid plans with realtime weather.</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+      <section>
+        <h2>Configuration overview</h2>
+        <div class="feature-grid">
+          <article class="feature-card">
+            <h3>Provider ordering</h3>
+            <p>
+              `providers` accepts an array like `['weatherbit', 'openweather', 'nws']`.
+              The first provider to resolve wins; failures automatically fall
+              through to the next provider.
+            </p>
+          </article>
+          <article class="feature-card">
+            <h3>API keys</h3>
+            <p>
+              Use the `apiKeys` map to supply credentials keyed by provider name.
+              Providers without keys (e.g. NWS) can be omitted.
+            </p>
+          </article>
+          <article class="feature-card">
+            <h3>Caching</h3>
+            <p>
+              Pass a Redis client to enable cross-instance caching. Otherwise an
+              in-memory store is used. Adjust TTL and geohash precision as needed.
+            </p>
+          </article>
+          <article class="feature-card">
+            <h3>Observability</h3>
+            <p>
+              Inject a custom outcome reporter to log or emit metrics whenever a
+              provider call succeeds or fails.
+            </p>
+          </article>
+        </div>
+      </section>
+
+      <section>
+        <h2>Fallback &amp; error handling</h2>
+        <p>
+          Weather Plus normalizes provider errors into a shared taxonomy so you can
+          route retries and observability in a single place. When all providers
+          fail, the most recent error is re-thrown with cause information preserved.
+        </p>
+      </section>
+
+      <section>
+        <h2>Helpful links</h2>
+        <ul>
+          <li>
+            <a href="https://github.com/TextureHQ/weather-plus#readme" target="_blank"
+              >Project README</a
+            >
+          </li>
+          <li>
+            <a href="https://github.com/TextureHQ/weather-plus/tree/main/docs/rfcs"
+              target="_blank"
+              >RFCs &amp; architecture decisions</a
+            >
+          </li>
+          <li>
+            <a href="https://www.npmjs.com/package/weather-plus" target="_blank"
+              >npm package details</a
+            >
+          </li>
+        </ul>
+      </section>
+    </main>
+
+    <footer>
+      Built with ❤️ by the Weather Plus maintainers &middot;
+      <a href="https://github.com/TextureHQ/weather-plus">Contribute on GitHub</a>
+    </footer>
+  </body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -95,6 +95,39 @@
         text-align: center;
         color: #64748b;
       }
+
+      footer .texture-wordmark {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+      }
+
+      footer .texture-wordmark img {
+        height: 20px;
+      }
+
+      .hero-logo {
+        margin-top: 2rem;
+      }
+
+      .hero-logo img {
+        max-width: 180px;
+      }
+
+      .provider-logo {
+        height: 18px;
+        vertical-align: baseline;
+        margin-left: 0.35rem;
+      }
+
+      @media (max-width: 768px) {
+        header.hero h1 {
+          font-size: clamp(2.2rem, 6vw, 3rem);
+        }
+        .hero-logo img {
+          max-width: 140px;
+        }
+      }
     </style>
   </head>
   <body>
@@ -106,6 +139,12 @@
           Weather Plus wraps NWS, OpenWeather, Tomorrow.io, and Weatherbit behind a
           single, type-safe interface with built-in caching and graceful fallback.
         </p>
+        <div class="hero-logo">
+          <img
+            src="https://cdn.texturehq.com/texture-wordmark-black.png"
+            alt="Texture HQ"
+          />
+        </div>
         <div class="cta-buttons">
           <a class="contrast" href="https://www.npmjs.com/package/weather-plus"
             >View on npm</a
@@ -276,7 +315,14 @@ console.log(report.conditions.value);
     </main>
 
     <footer>
-      Built with ❤️ by the Weather Plus maintainers &middot;
+      <span class="texture-wordmark">
+        Built with ❤️ in NYC by
+        <img
+          src="https://cdn.texturehq.com/texture-wordmark-black.png"
+          alt="Texture HQ"
+        />
+      </span>
+      &middot;
       <a href="https://github.com/TextureHQ/weather-plus">Contribute on GitHub</a>
     </footer>
   </body>


### PR DESCRIPTION
## Summary
- add  and  so GitHub Pages serves a single-page documentation site
- style the page with Pico.css + subtle custom styling, highlighting features, quickstart, provider table, config guidance, and helpful links
- add Texture branding in the hero and footer, and link the site from the README

## Testing
- yarn lint