### PR TITLE
feat: add getWeatherBatch() for single-round-trip multi-location fetch (CIR-998)

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,58 @@ const weather = await weatherPlus.getWeather(51.5074, -0.1278, { bypassCache: tr
 
 This will not entirely bypass the cache, it bypasses it for the read request and then the returned data is cached again for future use.
 
+### Batch Requests
+
+When you need weather for many coordinates at once (e.g. a cron that refreshes a
+fleet of sites), use `getWeatherBatch` instead of calling `getWeather` in a loop.
+It collapses the per-coordinate work into a single Redis `MGET` for all cache
+lookups, fans out provider calls **only** for cache misses with a bounded
+concurrency, and pipelines the write-back in one round trip. Coordinates that
+fall in the same geohash bucket are de-duplicated so each unique location is
+fetched at most once.
+
+```ts
+const results = await weatherPlus.getWeatherBatch([
+  { lat: 40.7128, lng: -74.006 },  // New York
+  { lat: 34.0522, lng: -118.2437 }, // Los Angeles
+  { lat: 41.8781, lng: -87.6298 },  // Chicago
+]);
+
+// Results are aligned to the input order. Each item has EITHER `weather` OR
+// `error` set, so a single bad coordinate never fails the whole batch.
+for (const r of results) {
+  if (r.error) {
+    console.warn(`Failed for ${r.lat},${r.lng}: ${r.error}`);
+  } else {
+    console.log(`${r.lat},${r.lng}:`, r.weather?.temperature);
+  }
+}
+```
+
+The result shape:
+
+```ts
+interface IWeatherBatchResult {
+  lat: number;
+  lng: number;
+  weather?: IWeatherData; // present on success
+  error?: string;         // present on failure (invalid coord or provider error)
+}
+```
+
+`getWeatherBatch` accepts the same `bypassCache` option as `getWeather`, plus a
+per-call `concurrency` override:
+
+```ts
+const results = await weatherPlus.getWeatherBatch(coords, {
+  bypassCache: false,
+  concurrency: 20, // cap concurrent provider calls for cache misses
+});
+```
+
+The default concurrency cap for the miss fan-out is `15`, and can also be set
+globally on the client via the `batchConcurrency` constructor option.
+
 ### Request Timeout
 
 You can configure the timeout for HTTP requests to weather providers. The default timeout is 10 seconds (10000 milliseconds).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weather-plus",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "description": "Weather Plus is a powerful wrapper around various Weather APIs that simplifies adding weather data to your application",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",

--- a/src/cache.test.ts
+++ b/src/cache.test.ts
@@ -226,4 +226,90 @@ describe('Cache', () => {
         expect(parsed.provider).toBe('nws'); // Verify provider name
     });
   });
+
+  describe('Batch operations', () => {
+    describe('mget (Redis)', () => {
+      it('returns [] without touching Redis for an empty key list', async () => {
+        const result = await cache.mget([]);
+        expect(result).toEqual([]);
+        expect(mockRedisClient.mGet).toBeUndefined();
+      });
+
+      it('issues a single MGET and preserves order', async () => {
+        mockRedisClient.mGet = jest.fn().mockResolvedValue(['a', null, 'c']);
+        cache = new Cache(mockRedisClient as unknown as RedisClientType);
+
+        const result = await cache.mget(['k1', 'k2', 'k3']);
+
+        expect(result).toEqual(['a', null, 'c']);
+        expect(mockRedisClient.mGet).toHaveBeenCalledTimes(1);
+        expect(mockRedisClient.mGet).toHaveBeenCalledWith(['k1', 'k2', 'k3']);
+      });
+
+      it('normalizes undefined values to null', async () => {
+        mockRedisClient.mGet = jest.fn().mockResolvedValue(['a', undefined]);
+        cache = new Cache(mockRedisClient as unknown as RedisClientType);
+
+        const result = await cache.mget(['k1', 'k2']);
+
+        expect(result).toEqual(['a', null]);
+      });
+    });
+
+    describe('mset (Redis)', () => {
+      it('does nothing for an empty entry list', async () => {
+        mockRedisClient.multi = jest.fn();
+        cache = new Cache(mockRedisClient as unknown as RedisClientType);
+
+        await cache.mset([]);
+
+        expect(mockRedisClient.multi).not.toHaveBeenCalled();
+      });
+
+      it('pipelines SET ... EX preserving per-key TTL and default fallback', async () => {
+        const setSpy = jest.fn().mockReturnThis();
+        const execSpy = jest.fn().mockResolvedValue([]);
+        mockRedisClient.multi = jest.fn().mockReturnValue({ set: setSpy, exec: execSpy });
+        cache = new Cache(mockRedisClient as unknown as RedisClientType, 300);
+
+        await cache.mset([
+          { key: 'k1', value: 'v1', ttl: 600 },
+          { key: 'k2', value: 'v2' },
+        ]);
+
+        expect(mockRedisClient.multi).toHaveBeenCalledTimes(1);
+        expect(setSpy).toHaveBeenNthCalledWith(1, 'k1', 'v1', { EX: 600 });
+        expect(setSpy).toHaveBeenNthCalledWith(2, 'k2', 'v2', { EX: 300 });
+        expect(execSpy).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe('memory fallback', () => {
+      beforeEach(() => {
+        cache = new Cache();
+      });
+
+      it('mget reads back mset values in order with misses as null', async () => {
+        await cache.mset([
+          { key: 'k1', value: 'v1' },
+          { key: 'k3', value: 'v3' },
+        ]);
+
+        const result = await cache.mget(['k1', 'k2', 'k3']);
+        expect(result).toEqual(['v1', null, 'v3']);
+      });
+
+      it('mget honors TTL expiry', async () => {
+        jest.useFakeTimers();
+        await cache.mset([{ key: 'k1', value: 'v1', ttl: 100 }]);
+
+        jest.advanceTimersByTime(99 * 1000);
+        expect(await cache.mget(['k1'])).toEqual(['v1']);
+
+        jest.advanceTimersByTime(2 * 1000);
+        expect(await cache.mget(['k1'])).toEqual([null]);
+        jest.useRealTimers();
+      });
+    });
+  });
 });

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -46,4 +46,52 @@ export class Cache {
     const expiresAt = Date.now() + expiresIn * 1000;
     this.memoryCache.set(key, { value, expiresAt });
   }
+
+  // Batch read: retrieve many keys in a single round trip.
+  // Redis uses MGET; the in-memory fallback reads each key with the same
+  // freshness/eviction semantics as get(). Results are aligned to `keys` order,
+  // with `null` for any missing/expired entry.
+  async mget(keys: string[]): Promise<(string | null)[]> {
+    if (keys.length === 0) {
+      return [];
+    }
+
+    if (this.cacheType === 'redis' && this.redisClient) {
+      const values = await this.redisClient.mGet(keys);
+      // node-redis types mGet as (string | null)[]; normalize any undefined to null.
+      return values.map((val) => (val === undefined ? null : val));
+    }
+
+    return keys.map((key) => {
+      const item = this.memoryCache.get(key);
+      if (item && item.expiresAt > Date.now()) {
+        return item.value;
+      }
+      this.memoryCache.delete(key);
+      return null;
+    });
+  }
+
+  // Batch write: persist many entries in a single pipelined round trip.
+  // A plain Redis MSET cannot carry per-key TTLs, so we pipeline SET ... EX via
+  // multi()/exec() to preserve the same expiry semantics as set().
+  async mset(entries: Array<{ key: string; value: string; ttl?: number }>): Promise<void> {
+    if (entries.length === 0) {
+      return;
+    }
+
+    if (this.cacheType === 'redis' && this.redisClient) {
+      const pipeline = this.redisClient.multi();
+      for (const { key, value, ttl } of entries) {
+        pipeline.set(key, value, { EX: ttl ?? this.defaultTTL });
+      }
+      await pipeline.exec();
+      return;
+    }
+
+    for (const { key, value, ttl } of entries) {
+      const expiresAt = Date.now() + (ttl ?? this.defaultTTL) * 1000;
+      this.memoryCache.set(key, { value, expiresAt });
+    }
+  }
 }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -326,4 +326,19 @@ describe('WeatherPlus Library', () => {
     expect(error).toBeInstanceOf(Error);
     expect(error.message).toBe('Test error');
   });
+
+  it('should expose getWeatherBatch and align results to input order', async () => {
+    const weatherPlus = new WeatherPlus();
+    // Use invalid coordinates so the batch resolves without any provider I/O:
+    // this exercises the top-level WeatherPlus.getWeatherBatch delegation and
+    // the per-item error-isolation path.
+    const results = await weatherPlus.getWeatherBatch([
+      { lat: 999, lng: 0 },
+      { lat: 0, lng: 999 },
+    ]);
+
+    expect(results).toHaveLength(2);
+    expect(results[0]).toMatchObject({ lat: 999, lng: 0, error: 'Invalid latitude or longitude' });
+    expect(results[1]).toMatchObject({ lat: 0, lng: 999, error: 'Invalid latitude or longitude' });
+  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,12 @@
 import { WeatherService } from './weatherService';
 import { InvalidProviderLocationError, ProviderNotSupportedError, WeatherProviderError } from './errors';
 import { RedisClientType } from 'redis';
-import { GetWeatherOptions } from './weatherService';
+import {
+  GetWeatherOptions,
+  GetWeatherBatchOptions,
+  IWeatherCoordinate,
+  IWeatherBatchResult,
+} from './weatherService';
 import { IWeatherData } from './interfaces';
 import { ProviderId } from './providers/capabilities';
 
@@ -13,6 +18,7 @@ interface WeatherPlusOptions {
   geohashPrecision?: number;                 // Optional geohash precision for caching
   cacheTTL?: number;                         // Optional cache time-to-live in seconds
   timeout?: number;                          // Optional timeout in milliseconds for provider requests (default: 10000ms)
+  batchConcurrency?: number;                 // Optional cap on concurrent provider calls during getWeatherBatch (default: 15)
 }
 
 // Main WeatherPlus class that users will interact with
@@ -27,6 +33,7 @@ class WeatherPlus {
       apiKeys: options.apiKeys,
       cacheTTL: options.cacheTTL,
       timeout: options.timeout ?? 10000,
+      batchConcurrency: options.batchConcurrency,
     });
   }
 
@@ -34,8 +41,28 @@ class WeatherPlus {
   async getWeather(lat: number, lng: number, options?: GetWeatherOptions): Promise<IWeatherData> {
     return this.weatherService.getWeather(lat, lng, options);
   }
+
+  // Public method to get weather data for many coordinates in a single batch.
+  // Collapses cache lookups into one MGET, fans out only cache misses with a
+  // bounded concurrency, and pipelines the write-back. Results are aligned to
+  // the input order with per-item error isolation.
+  async getWeatherBatch(
+    coordinates: IWeatherCoordinate[],
+    options?: GetWeatherBatchOptions,
+  ): Promise<IWeatherBatchResult[]> {
+    return this.weatherService.getWeatherBatch(coordinates, options);
+  }
 }
 
-export { WeatherService, GetWeatherOptions, InvalidProviderLocationError, ProviderNotSupportedError, WeatherProviderError };
+export {
+  WeatherService,
+  GetWeatherOptions,
+  GetWeatherBatchOptions,
+  IWeatherCoordinate,
+  IWeatherBatchResult,
+  InvalidProviderLocationError,
+  ProviderNotSupportedError,
+  WeatherProviderError,
+};
 export * from './interfaces';
 export default WeatherPlus;

--- a/src/weatherService.ts
+++ b/src/weatherService.ts
@@ -230,6 +230,7 @@ export class WeatherService {
       }
     }
 
+    /* istanbul ignore next -- defensive: constructor guarantees >=1 provider, so lastError is always set here */
     throw lastError || new Error('Unable to retrieve weather data from any provider.');
   }
 
@@ -292,6 +293,7 @@ export class WeatherService {
         if (raw) {
           try {
             const parsed: IWeatherData = JSON.parse(raw);
+            /* istanbul ignore next -- defensive: key is always present in indicesByGeohash */
             for (const idx of indicesByGeohash.get(key) ?? []) {
               results[idx].weather = parsed;
             }
@@ -317,6 +319,7 @@ export class WeatherService {
     const worker = async (): Promise<void> => {
       while (cursor < missGeohashes.length) {
         const key = missGeohashes[cursor++];
+        /* istanbul ignore next -- defensive: key is always present in indicesByGeohash */
         const targetIndices = indicesByGeohash.get(key) ?? [];
         try {
           const { result, cacheValue } = await this.fetchFreshWeatherByGeohash(key);
@@ -325,6 +328,7 @@ export class WeatherService {
             results[idx].weather = result;
           }
         } catch (error) {
+          /* istanbul ignore next -- defensive: optional chain guards a null/undefined throw */
           const message = (error as Error)?.message ?? 'Unable to retrieve weather data';
           for (const idx of targetIndices) {
             results[idx].error = message;

--- a/src/weatherService.ts
+++ b/src/weatherService.ts
@@ -20,7 +20,12 @@ interface WeatherServiceOptions {
   geohashPrecision?: number;                 // Optional geohash precision for caching
   cacheTTL?: number;                         // Optional cache time-to-live in seconds
   timeout?: number;                          // Optional timeout in milliseconds for provider requests
+  batchConcurrency?: number;                 // Optional cap on concurrent provider calls during a batch (default 15)
 }
+
+// Default upper bound on concurrent provider fetches issued for cache misses
+// within a single getWeatherBatch call.
+const DEFAULT_BATCH_CONCURRENCY = 15;
 
 // Schema for validating latitude and longitude coordinates
 const CoordinatesSchema = z.object({
@@ -33,10 +38,34 @@ export interface GetWeatherOptions {
   bypassCache?: boolean;
 }
 
+// Options for the batch entry point.
+export interface GetWeatherBatchOptions {
+  bypassCache?: boolean;
+  // Per-call override of the concurrency cap on provider fetches for misses.
+  concurrency?: number;
+}
+
+// A single coordinate in a batch request.
+export interface IWeatherCoordinate {
+  lat: number;
+  lng: number;
+}
+
+// A single result in a batch response, aligned to the input coordinate order.
+// Exactly one of `weather` or `error` is populated per item so that one bad
+// coordinate never fails the whole batch.
+export interface IWeatherBatchResult {
+  lat: number;
+  lng: number;
+  weather?: IWeatherData;
+  error?: string;
+}
+
 export class WeatherService {
   private cache: Cache;
   private providers: IWeatherProvider[];
   private geohashPrecision: number;
+  private batchConcurrency: number;
 
   constructor(options: WeatherServiceOptions) {
     log('Initializing WeatherService with options:', options);
@@ -69,6 +98,16 @@ export class WeatherService {
       this.geohashPrecision = options.geohashPrecision;
     } else {
       this.geohashPrecision = 5;
+    }
+
+    // Set batch concurrency cap; default to DEFAULT_BATCH_CONCURRENCY.
+    if (options.batchConcurrency !== undefined) {
+      if (!Number.isInteger(options.batchConcurrency) || options.batchConcurrency <= 0) {
+        throw new Error('Invalid batchConcurrency. It must be an integer greater than 0.');
+      }
+      this.batchConcurrency = options.batchConcurrency;
+    } else {
+      this.batchConcurrency = DEFAULT_BATCH_CONCURRENCY;
     }
   }
 
@@ -143,5 +182,165 @@ export class WeatherService {
 
     // If all providers fail, throw the last encountered error
     throw lastError || new Error('Unable to retrieve weather data from any provider.');
+  }
+
+  /**
+   * Fetch fresh weather for a single geohash from the provider chain.
+   *
+   * Mirrors the provider-fallback loop used by getWeather, but returns both the
+   * value to hand back to the caller (cached: false) and the serialized string
+   * to persist to cache (cached: true). Kept separate so getWeather stays
+   * behaviorally unchanged while the batch path can reuse the exact same logic
+   * and cache its writes in a single pipeline.
+   */
+  private async fetchFreshWeatherByGeohash(
+    locationGeohash: string,
+  ): Promise<{ result: IWeatherData; cacheValue: string }> {
+    let lastError: Error | null = null;
+
+    for (const provider of this.providers) {
+      try {
+        const { latitude: geohashLat, longitude: geohashLng } = geohash.decode(locationGeohash);
+
+        if (provider.name === 'nws' && !isLocationInUS(geohashLat, geohashLng)) {
+          throw new InvalidProviderLocationError(
+            `${provider.name} provider does not support the provided location.`,
+          );
+        }
+
+        const providerWeather: Partial<IWeatherProviderWeatherData> = await provider.getWeather(
+          geohashLat,
+          geohashLng,
+        );
+
+        const weatherForCache = {
+          ...providerWeather,
+          provider: provider.name,
+          cached: true,
+          cachedAt: new Date().toISOString(),
+        };
+
+        return {
+          result: { ...weatherForCache, cached: false, cachedAt: undefined },
+          cacheValue: JSON.stringify(weatherForCache),
+        };
+      } catch (error) {
+        log(`Error with provider ${provider.name}:`, error);
+        lastError = error as Error;
+      }
+    }
+
+    throw lastError || new Error('Unable to retrieve weather data from any provider.');
+  }
+
+  /**
+   * Batch counterpart to getWeather.
+   *
+   * Resolves weather for many coordinates while collapsing the per-coordinate
+   * N+1 pattern into: one MGET for all cache lookups, a bounded fan-out of
+   * provider calls for misses only, and one pipelined write-back. Coordinates
+   * that share a geohash bucket are de-duplicated so each unique location is
+   * fetched at most once. Results are returned aligned to the input order, and
+   * a failure for any single coordinate is isolated to that item's `error`
+   * field rather than rejecting the whole batch.
+   */
+  public async getWeatherBatch(
+    coordinates: IWeatherCoordinate[],
+    options?: GetWeatherBatchOptions,
+  ): Promise<IWeatherBatchResult[]> {
+    const results: IWeatherBatchResult[] = coordinates.map(({ lat, lng }) => ({ lat, lng }));
+
+    if (coordinates.length === 0) {
+      return results;
+    }
+
+    // Map each valid coordinate to its geohash bucket, grouping duplicate
+    // buckets so we only look up / fetch each unique location once. Invalid
+    // coordinates are marked immediately and excluded from all round trips.
+    const indicesByGeohash = new Map<string, number[]>();
+
+    coordinates.forEach(({ lat, lng }, index) => {
+      const validation = CoordinatesSchema.safeParse({ lat, lng });
+      if (!validation.success) {
+        results[index].error = 'Invalid latitude or longitude';
+        return;
+      }
+
+      const key = geohash.encode(lat, lng, this.geohashPrecision);
+      const existing = indicesByGeohash.get(key);
+      if (existing) {
+        existing.push(index);
+      } else {
+        indicesByGeohash.set(key, [index]);
+      }
+    });
+
+    const uniqueGeohashes = [...indicesByGeohash.keys()];
+    if (uniqueGeohashes.length === 0) {
+      return results;
+    }
+
+    // 1) Single MGET for every unique geohash (skipped when bypassing cache).
+    const missGeohashes: string[] = [];
+    if (options?.bypassCache) {
+      missGeohashes.push(...uniqueGeohashes);
+    } else {
+      const cachedValues = await this.cache.mget(uniqueGeohashes);
+
+      uniqueGeohashes.forEach((key, i) => {
+        const raw = cachedValues[i];
+        if (raw) {
+          try {
+            const parsed: IWeatherData = JSON.parse(raw);
+            for (const idx of indicesByGeohash.get(key) ?? []) {
+              results[idx].weather = parsed;
+            }
+          } catch {
+            // Corrupt cache entry: treat as a miss and refetch.
+            missGeohashes.push(key);
+          }
+        } else {
+          missGeohashes.push(key);
+        }
+      });
+    }
+
+    if (missGeohashes.length === 0) {
+      return results;
+    }
+
+    // 2) Bounded fan-out of provider fetches for misses only.
+    const concurrency = Math.max(1, options?.concurrency ?? this.batchConcurrency);
+    const cacheWrites: Array<{ key: string; value: string; ttl?: number }> = [];
+    let cursor = 0;
+
+    const worker = async (): Promise<void> => {
+      while (cursor < missGeohashes.length) {
+        const key = missGeohashes[cursor++];
+        const targetIndices = indicesByGeohash.get(key) ?? [];
+        try {
+          const { result, cacheValue } = await this.fetchFreshWeatherByGeohash(key);
+          cacheWrites.push({ key, value: cacheValue });
+          for (const idx of targetIndices) {
+            results[idx].weather = result;
+          }
+        } catch (error) {
+          const message = (error as Error)?.message ?? 'Unable to retrieve weather data';
+          for (const idx of targetIndices) {
+            results[idx].error = message;
+          }
+        }
+      }
+    };
+
+    const workerCount = Math.min(concurrency, missGeohashes.length);
+    await Promise.all(Array.from({ length: workerCount }, () => worker()));
+
+    // 3) Single pipelined write-back for all freshly fetched entries.
+    if (cacheWrites.length > 0) {
+      await this.cache.mset(cacheWrites);
+    }
+
+    return results;
   }
 }

--- a/src/weatherServiceBatch.test.ts
+++ b/src/weatherServiceBatch.test.ts
@@ -1,0 +1,228 @@
+import { WeatherService } from './weatherService';
+import { IWeatherUnits, IWeatherData } from './interfaces';
+
+/**
+ * Controllable in-memory Cache mock that records how many round trips the batch
+ * path makes. This lets us assert the "one MGET + one pipelined write-back"
+ * contract directly, rather than inferring it from behavior.
+ */
+const cacheStore = new Map<string, string>();
+const cacheCounters = { mget: 0, mset: 0, get: 0, set: 0 };
+
+jest.mock('./cache', () => {
+  return {
+    Cache: jest.fn().mockImplementation(() => ({
+      get: jest.fn(async (key: string) => {
+        cacheCounters.get++;
+        return cacheStore.get(key) ?? null;
+      }),
+      set: jest.fn(async (key: string, value: string) => {
+        cacheCounters.set++;
+        cacheStore.set(key, value);
+      }),
+      mget: jest.fn(async (keys: string[]) => {
+        cacheCounters.mget++;
+        return keys.map((k) => cacheStore.get(k) ?? null);
+      }),
+      mset: jest.fn(async (entries: Array<{ key: string; value: string }>) => {
+        cacheCounters.mset++;
+        for (const { key, value } of entries) {
+          cacheStore.set(key, value);
+        }
+      }),
+    })),
+  };
+});
+
+// Provider instrumentation: count calls and track peak concurrency so we can
+// assert the miss fan-out honors the configured cap.
+const providerState = {
+  calls: 0,
+  active: 0,
+  peakConcurrency: 0,
+  // The provider is invoked with the decoded geohash-center coords, not the raw
+  // input, so we key forced failures off a longitude threshold instead of exact
+  // coordinates: any call west of failWestOfLng rejects.
+  failWestOfLng: undefined as number | undefined,
+  delayMs: 0,
+};
+
+jest.mock('./providers/nws/client', () => {
+  const originalModule = jest.requireActual('./providers/nws/client');
+
+  class MockNWSProvider extends originalModule.NWSProvider {
+    async getWeather(lat: number, lng: number) {
+      providerState.calls++;
+      providerState.active++;
+      providerState.peakConcurrency = Math.max(providerState.peakConcurrency, providerState.active);
+      try {
+        if (providerState.delayMs > 0) {
+          await new Promise((r) => setTimeout(r, providerState.delayMs));
+        }
+        if (providerState.failWestOfLng !== undefined && lng < providerState.failWestOfLng) {
+          throw new Error(`forced provider failure for ${lat},${lng}`);
+        }
+        return {
+          temperature: { value: 15, unit: IWeatherUnits.C },
+          provider: 'nws',
+        } as IWeatherData;
+      } finally {
+        providerState.active--;
+      }
+    }
+  }
+
+  return { __esModule: true, ...originalModule, NWSProvider: MockNWSProvider };
+});
+
+// US coordinates (NWS supported). Distinct enough to land in different geohash-5 buckets.
+const NYC = { lat: 40.7128, lng: -74.006 };
+const LA = { lat: 34.0522, lng: -118.2437 };
+const CHI = { lat: 41.8781, lng: -87.6298 };
+
+describe('WeatherService.getWeatherBatch', () => {
+  let service: WeatherService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    cacheStore.clear();
+    cacheCounters.mget = 0;
+    cacheCounters.mset = 0;
+    cacheCounters.get = 0;
+    cacheCounters.set = 0;
+    providerState.calls = 0;
+    providerState.active = 0;
+    providerState.peakConcurrency = 0;
+    providerState.failWestOfLng = undefined;
+    providerState.delayMs = 0;
+    service = new WeatherService({ providers: ['nws'] });
+  });
+
+  it('returns [] for an empty input without any round trips', async () => {
+    const results = await service.getWeatherBatch([]);
+    expect(results).toEqual([]);
+    expect(cacheCounters.mget).toBe(0);
+    expect(cacheCounters.mset).toBe(0);
+    expect(providerState.calls).toBe(0);
+  });
+
+  it('uses a single MGET and a single pipelined write-back for all misses', async () => {
+    const results = await service.getWeatherBatch([NYC, LA, CHI]);
+
+    expect(cacheCounters.mget).toBe(1);
+    expect(cacheCounters.mset).toBe(1);
+    expect(cacheCounters.get).toBe(0);
+    expect(cacheCounters.set).toBe(0);
+    expect(providerState.calls).toBe(3);
+    expect(results).toHaveLength(3);
+    for (const r of results) {
+      expect(r.error).toBeUndefined();
+      expect(r.weather?.provider).toBe('nws');
+      // Freshly fetched results are handed back with cached:false.
+      expect(r.weather?.cached).toBe(false);
+    }
+  });
+
+  it('fetches from providers only for cache misses', async () => {
+    // Pre-warm LA in the cache.
+    await service.getWeatherBatch([LA]);
+    expect(providerState.calls).toBe(1);
+    providerState.calls = 0;
+
+    const results = await service.getWeatherBatch([NYC, LA, CHI]);
+
+    // Only NYC + CHI hit the provider; LA served from cache.
+    expect(providerState.calls).toBe(2);
+    const la = results.find((r) => r.lat === LA.lat && r.lng === LA.lng);
+    expect(la?.weather?.cached).toBe(true); // came from cache
+  });
+
+  it('deduplicates coordinates that share a geohash bucket (one provider call, both filled)', async () => {
+    const nearNYC = { lat: NYC.lat + 0.0001, lng: NYC.lng + 0.0001 };
+    const results = await service.getWeatherBatch([NYC, nearNYC]);
+
+    expect(providerState.calls).toBe(1);
+    expect(results).toHaveLength(2);
+    expect(results[0].weather?.provider).toBe('nws');
+    expect(results[1].weather?.provider).toBe('nws');
+  });
+
+  it('returns results aligned to input order', async () => {
+    const results = await service.getWeatherBatch([LA, NYC, CHI]);
+    expect(results.map((r) => ({ lat: r.lat, lng: r.lng }))).toEqual([
+      { lat: LA.lat, lng: LA.lng },
+      { lat: NYC.lat, lng: NYC.lng },
+      { lat: CHI.lat, lng: CHI.lng },
+    ]);
+  });
+
+  it('isolates invalid coordinates without a round trip for them', async () => {
+    const bad = { lat: 999, lng: 999 };
+    const results = await service.getWeatherBatch([NYC, bad, CHI]);
+
+    expect(results[1].error).toBe('Invalid latitude or longitude');
+    expect(results[1].weather).toBeUndefined();
+    expect(results[0].weather?.provider).toBe('nws');
+    expect(results[2].weather?.provider).toBe('nws');
+    // Only the two valid coords reached the provider.
+    expect(providerState.calls).toBe(2);
+  });
+
+  it('isolates provider failures to the failing item, not the whole batch', async () => {
+    // Fail any provider call west of -100 => LA fails, NYC/CHI (east) succeed.
+    providerState.failWestOfLng = -100;
+    const results = await service.getWeatherBatch([NYC, LA, CHI]);
+
+    const la = results.find((r) => r.lat === LA.lat);
+    expect(la?.error).toContain('forced provider failure');
+    expect(la?.weather).toBeUndefined();
+    expect(results.find((r) => r.lat === NYC.lat)?.weather?.provider).toBe('nws');
+    expect(results.find((r) => r.lat === CHI.lat)?.weather?.provider).toBe('nws');
+    // Failed fetch is not written back to cache.
+    const laGeohash = require('ngeohash').encode(LA.lat, LA.lng, 5);
+    expect(cacheStore.has(laGeohash)).toBe(false);
+  });
+
+  it('bypassCache refetches all coordinates and skips the MGET', async () => {
+    await service.getWeatherBatch([NYC]); // warm cache
+    providerState.calls = 0;
+    cacheCounters.mget = 0;
+
+    const results = await service.getWeatherBatch([NYC], { bypassCache: true });
+
+    expect(cacheCounters.mget).toBe(0); // no read round trip when bypassing
+    expect(providerState.calls).toBe(1); // refetched despite being cached
+    expect(results[0].weather?.provider).toBe('nws');
+  });
+
+  it('respects the concurrency cap for the miss fan-out', async () => {
+    providerState.delayMs = 20;
+    // Six clearly-US metros in distinct geohash-5 buckets.
+    const coords = [
+      { lat: 40.7128, lng: -74.006 }, // New York
+      { lat: 34.0522, lng: -118.2437 }, // Los Angeles
+      { lat: 41.8781, lng: -87.6298 }, // Chicago
+      { lat: 29.7604, lng: -95.3698 }, // Houston
+      { lat: 39.7392, lng: -104.9903 }, // Denver
+      { lat: 33.4484, lng: -112.074 }, // Phoenix
+    ];
+
+    await service.getWeatherBatch(coords, { concurrency: 2 });
+
+    expect(providerState.calls).toBe(6);
+    expect(providerState.peakConcurrency).toBeLessThanOrEqual(2);
+    expect(providerState.peakConcurrency).toBeGreaterThan(0);
+  });
+
+  it('serves an all-cache-hit batch with zero provider calls and no write-back', async () => {
+    await service.getWeatherBatch([NYC, LA]); // warm
+    providerState.calls = 0;
+    cacheCounters.mset = 0;
+
+    const results = await service.getWeatherBatch([NYC, LA]);
+
+    expect(providerState.calls).toBe(0);
+    expect(cacheCounters.mset).toBe(0); // nothing fresh to persist
+    expect(results.every((r) => r.weather?.cached === true)).toBe(true);
+  });
+});

--- a/src/weatherServiceBatch.test.ts
+++ b/src/weatherServiceBatch.test.ts
@@ -214,6 +214,52 @@ describe('WeatherService.getWeatherBatch', () => {
     expect(providerState.peakConcurrency).toBeGreaterThan(0);
   });
 
+  it('treats a corrupt cache entry as a miss and refetches', async () => {
+    const geohashKey = require('ngeohash').encode(NYC.lat, NYC.lng, 5);
+    cacheStore.set(geohashKey, '{ not valid json');
+
+    const results = await service.getWeatherBatch([NYC]);
+
+    expect(providerState.calls).toBe(1); // refetched despite a cache entry existing
+    expect(results[0].weather?.provider).toBe('nws');
+    expect(results[0].error).toBeUndefined();
+  });
+
+  it('returns early (no round trips) when every coordinate is invalid', async () => {
+    const results = await service.getWeatherBatch([
+      { lat: 999, lng: 0 },
+      { lat: 0, lng: 999 },
+    ]);
+
+    expect(cacheCounters.mget).toBe(0);
+    expect(providerState.calls).toBe(0);
+    expect(results.every((r) => r.error === 'Invalid latitude or longitude')).toBe(true);
+  });
+
+  it('honors a global batchConcurrency client option', async () => {
+    providerState.delayMs = 20;
+    const capped = new WeatherService({ providers: ['nws'], batchConcurrency: 2 });
+    const coords = [
+      { lat: 40.7128, lng: -74.006 },
+      { lat: 34.0522, lng: -118.2437 },
+      { lat: 41.8781, lng: -87.6298 },
+      { lat: 29.7604, lng: -95.3698 },
+    ];
+
+    await capped.getWeatherBatch(coords);
+
+    expect(providerState.peakConcurrency).toBeLessThanOrEqual(2);
+  });
+
+  it('rejects an invalid batchConcurrency option at construction', () => {
+    expect(() => new WeatherService({ providers: ['nws'], batchConcurrency: 0 })).toThrow(
+      'Invalid batchConcurrency',
+    );
+    expect(() => new WeatherService({ providers: ['nws'], batchConcurrency: 1.5 })).toThrow(
+      'Invalid batchConcurrency',
+    );
+  });
+
   it('serves an all-cache-hit batch with zero provider calls and no write-back', async () => {
     await service.getWeatherBatch([NYC, LA]); // warm
     providerState.calls = 0;

--- a/src/weatherServiceBatch.test.ts
+++ b/src/weatherServiceBatch.test.ts
@@ -279,6 +279,23 @@ describe('WeatherService.getWeatherBatch', () => {
     expect(cacheStore.has(londonGeohash)).toBe(false);
   });
 
+  it('coerces a non-Error thrown value into a readable per-item message', async () => {
+    // Force the provider to throw a non-Error (a string), hitting the
+    // `(error as Error)?.message ?? ...` fallback in the batch worker.
+    const throwingService = new WeatherService({ providers: ['nws'] });
+    const provider = (
+      throwingService as unknown as {
+        providers: Array<{ getWeather: (lat: number, lng: number) => Promise<unknown> }>;
+      }
+    ).providers[0];
+    provider.getWeather = () => Promise.reject('boom-string');
+
+    const results = await throwingService.getWeatherBatch([NYC]);
+
+    expect(results[0].weather).toBeUndefined();
+    expect(results[0].error).toBe('Unable to retrieve weather data');
+  });
+
   it('serves an all-cache-hit batch with zero provider calls and no write-back', async () => {
     await service.getWeatherBatch([NYC, LA]); // warm
     providerState.calls = 0;

--- a/src/weatherServiceBatch.test.ts
+++ b/src/weatherServiceBatch.test.ts
@@ -79,6 +79,9 @@ jest.mock('./providers/nws/client', () => {
 const NYC = { lat: 40.7128, lng: -74.006 };
 const LA = { lat: 34.0522, lng: -118.2437 };
 const CHI = { lat: 41.8781, lng: -87.6298 };
+// A valid, well-formed coordinate outside the US (London) — NWS does not serve it,
+// so the provider loop must reject it with InvalidProviderLocationError.
+const LONDON = { lat: 51.5074, lng: -0.1278 };
 
 describe('WeatherService.getWeatherBatch', () => {
   let service: WeatherService;
@@ -258,6 +261,22 @@ describe('WeatherService.getWeatherBatch', () => {
     expect(() => new WeatherService({ providers: ['nws'], batchConcurrency: 1.5 })).toThrow(
       'Invalid batchConcurrency',
     );
+  });
+
+  it('surfaces a per-item error when the only provider does not serve the location (non-US + NWS)', async () => {
+    // London is a valid lat/lng but NWS is US-only, so the provider chain
+    // exhausts and the item gets an isolated error rather than weather data.
+    const results = await service.getWeatherBatch([NYC, LONDON, CHI]);
+
+    const london = results.find((r) => r.lat === LONDON.lat && r.lng === LONDON.lng);
+    expect(london?.weather).toBeUndefined();
+    expect(london?.error).toContain('does not support the provided location');
+    // The valid US coords still resolve, proving the failure is isolated.
+    expect(results.find((r) => r.lat === NYC.lat)?.weather?.provider).toBe('nws');
+    expect(results.find((r) => r.lat === CHI.lat)?.weather?.provider).toBe('nws');
+    // A location the provider refused is never written back to cache.
+    const londonGeohash = require('ngeohash').encode(LONDON.lat, LONDON.lng, 5);
+    expect(cacheStore.has(londonGeohash)).toBe(false);
   });
 
   it('serves an all-cache-hit batch with zero provider calls and no write-back', async () => {


### PR DESCRIPTION
## What & why

Datadog flags a **Sequential Calls / N+1** latency anti-pattern on `resource:weather.location.update` in Texture's site weather-cache-updater cron. The prior fix ([mono #11866](https://github.com/TextureHQ/mono/pull/11866)) added an app-layer geohash dedup — but `weather-plus` **already** caches by geohash-5 against the same shared Redis client, so that dedup buys ~nothing and pushes the fan-out/cache concern into the wrong layer.

The right fix is in the library we own: give it a real batch API so the consumer can hand it an array and get out of the way.

## What this adds

`getWeatherBatch(coords, options?)` on `WeatherPlus` / `WeatherService`:

- **One `MGET`** for all cache lookups (instead of N `GET`s).
- **Fan-out only for cache misses**, with a bounded concurrency cap (`batchConcurrency` client option or per-call `concurrency`, default **15**).
- **One pipelined write-back** — `multi()` of `SET … EX` so per-key TTL is preserved (a plain `MSET` can't carry TTL).
- **Geohash de-duplication** — coords in the same geohash-5 bucket are fetched once and fanned back out to every input index.
- **Results aligned to input order** with **per-item error isolation** — an invalid coord or a provider failure sets that item's `error` field instead of rejecting the whole batch.

```ts
const results = await weatherPlus.getWeatherBatch([
  { lat: 40.7128, lng: -74.006 },
  { lat: 34.0522, lng: -118.2437 },
]);
// each item: { lat, lng, weather? , error? }
```

`Cache` gains `mget()` / `mset()` primitives (Redis `MGET` + `multi()` pipeline, with matching in-memory fallback semantics).

## Backward compatibility

`getWeather` is **byte-for-byte unchanged** — the batch path reuses the same provider-fallback logic via an extracted private helper. Purely additive API + a version bump `1.5.1 → 1.6.0`.

## Testing

- `src/weatherServiceBatch.test.ts` (new): single-MGET/single-writeback contract, misses-only fetch, geohash dedup, input-order alignment, invalid-coord isolation, provider-failure isolation, `bypassCache`, concurrency-cap enforcement, all-cache-hit zero-provider path.
- `src/cache.test.ts`: `mget`/`mset` for Redis (pipeline TTL assertions) + in-memory fallback (order, TTL expiry).
- Full suite: **184 tests green**. `biome lint` clean. `yarn build` (cjs+esm) clean.

## Publish note

Merge to `main` auto-publishes `1.6.0` to npm via `publish.yml` (version already bumped; no manual publish).

## Follow-up

Mono consumer adoption is tracked separately in **CIR-999** — a distinct PR will swap `weatherCacheUpdater` over to `getWeatherBatch` and remove the app-layer dedup + per-item `pLimit`.

Closes CIR-998.
