### PR TITLE
ci: publish to npm via Trusted Publisher (OIDC)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,22 +9,25 @@ jobs:
   test-and-publish:
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+      id-token: write # required for npm Trusted Publisher (OIDC)
+
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+      uses: actions/checkout@v4
 
     - name: Set up Node.js
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with:
         node-version: '20'
+        registry-url: 'https://registry.npmjs.org'
+
+    - name: Upgrade npm (OIDC trusted publishing requires npm >= 11.5.1)
+      run: npm install -g npm@latest
 
     - name: Install dependencies
-      run: yarn install
-
-    - name: Install jq
-      run: sudo apt-get install -y jq
+      run: yarn install --frozen-lockfile
 
     - name: Run tests
       run: yarn test
@@ -32,27 +35,20 @@ jobs:
     - name: Build it
       run: yarn build
 
-    - name: Get current version
-      id: get_version
-      run: echo "version=$(jq -r .version package.json)" >> $GITHUB_ENV
-
     - name: Check if version is published
       id: version_check
       run: |
-        PUBLISHED_VERSIONS=$(yarn info . versions --json | jq -r '.data')
-        CURRENT_VERSION=$(jq -r .version package.json)
-        if echo "$PUBLISHED_VERSIONS" | jq -e ". | index(\"$CURRENT_VERSION\")" > /dev/null; then
+        CURRENT_VERSION=$(node -p "require('./package.json').version")
+        PACKAGE_NAME=$(node -p "require('./package.json').name")
+        echo "Checking $PACKAGE_NAME@$CURRENT_VERSION on npm..."
+        if npm view "$PACKAGE_NAME@$CURRENT_VERSION" version > /dev/null 2>&1; then
           echo "Version $CURRENT_VERSION is already published."
-          exit 0
+          echo "new_version=false" >> "$GITHUB_OUTPUT"
         else
           echo "Version $CURRENT_VERSION is new and will be published."
-          echo "new_version=true" >> $GITHUB_ENV
+          echo "new_version=true" >> "$GITHUB_OUTPUT"
         fi
 
-    - name: Configure npm for authentication
-      if: env.new_version == 'true'
-      run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
-
     - name: Publish to npm
-      if: env.new_version == 'true'
-      run: yarn publish
+      if: steps.version_check.outputs.new_version == 'true'
+      run: npm publish


### PR DESCRIPTION
## What

Migrates the `weather-plus` npm publish workflow from a static `NPM_TOKEN` secret to npm's **Trusted Publisher (OIDC)** flow, which you just enabled on the package.

## Why

The publish for `1.6.0` failed on merge of #37:
```
error Couldn't publish package: "https://registry.yarnpkg.com/weather-plus: Not found"
```
That's the classic signature of an expired/invalid `NPM_TOKEN`. Trusted Publisher removes the token entirely — GitHub Actions authenticates to npm via short-lived OIDC, so there's nothing to rotate and we get build provenance for free.

## Changes

- Add `permissions: id-token: write` (required for OIDC)
- Replace `yarn publish` (yarn classic has no OIDC support) with `npm publish`
- Upgrade npm to latest — OIDC trusted publishing requires **npm >= 11.5.1**
- Bump `actions/checkout` + `actions/setup-node` to v4, add `registry-url`
- Idempotent already-published check via `npm view` (was `yarn info`)
- `yarn install --frozen-lockfile` for reproducible CI

## Notes

- npm Trusted Publisher config points at workflow filename `publish.yml` — unchanged, so it matches.
- `prepack` already runs `yarn build`; `dist` is in `files`. No packaging change.
- The `NPM_TOKEN` repo secret can be deleted after this merges (optional cleanup).
- Once merged, the push-to-main publish should land `1.6.0` (currently npm latest is still `1.5.1`).

Refs CIR-998.