### PR TITLE
feat: Add Precipitation properties to IWeatherData (Fixes CIR-1089)

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -7,6 +7,7 @@ export enum IWeatherUnits {
     mps = 'm/s',
     mph = 'mph',
     degrees = 'degrees',
+    mmh = 'mm/h',
 }
 
 export enum IWeatherKey {
@@ -18,6 +19,8 @@ export enum IWeatherKey {
     windSpeed = 'windSpeed',
     windGust = 'windGust',
     windDirection = 'windDirection',
+    precipitationRate = 'precipitationRate',
+    precipitationProbability = 'precipitationProbability',
     // Not available for NWS, but is available for OpenWeather
     // We could utilize this API: https://sunrise-sunset.org/api
     // To supply sunrise and sunset times for NWS. It's a free API, would need to add attribution.
@@ -34,6 +37,8 @@ export type WeatherProviderPropertyMap = {
     [IWeatherKey.windSpeed]: IWindSpeed;
     [IWeatherKey.windGust]: IWindGust;
     [IWeatherKey.windDirection]: IWindDirection;
+    [IWeatherKey.precipitationRate]: IPrecipitationRate;
+    [IWeatherKey.precipitationProbability]: IPrecipitationProbability;
     [IWeatherKey.sunrise]: ISunriseSunset;
     [IWeatherKey.sunset]: ISunriseSunset;
 };
@@ -61,4 +66,6 @@ export type ICloudiness = IBaseWeatherProperty<number, IWeatherUnits.percent>;
 export type IWindSpeed = IBaseWeatherProperty<number, IWeatherUnits.mps | IWeatherUnits.mph>;
 export type IWindGust = IBaseWeatherProperty<number, IWeatherUnits.mps | IWeatherUnits.mph>;
 export type IWindDirection = IBaseWeatherProperty<number, IWeatherUnits.degrees>;
+export type IPrecipitationRate = IBaseWeatherProperty<number, IWeatherUnits.mmh>;
+export type IPrecipitationProbability = IBaseWeatherProperty<number, IWeatherUnits.percent>;
 export type ISunriseSunset = IBaseWeatherProperty<string, IWeatherUnits.iso8601>;

--- a/src/providers/nws/client.test.ts
+++ b/src/providers/nws/client.test.ts
@@ -47,6 +47,8 @@ describe('NWSProvider', () => {
       windSpeed: { value: 15 },
       windGust: { value: 20 },
       windDirection: { value: 180 },
+      precipitationLastHour: { value: 10, unitCode: 'wmoUnit:mm' },
+      probabilityOfPrecipitation: { value: 40, unitCode: 'wmoUnit:percent' },
       cloudLayers: [
         { base: { unitCode: 'wmoUnit:m', value: 1000 }, amount: 'CLR' }
       ],
@@ -88,6 +90,39 @@ describe('NWSProvider', () => {
       windSpeed: { value: 15, unit: 'm/s' },
       windGust: { value: 20, unit: 'm/s' },
       windDirection: { value: 180, unit: 'degrees' },
+      precipitationRate: { value: 10, unit: 'mm/h' },
+      precipitationProbability: { value: 40, unit: 'percent' },
+    });
+  });
+
+  it('should extract precipitation rate and probability of precipitation', async () => {
+    mockObservationStationUrl();
+    mock.onGet('https://api.weather.gov/gridpoints/XYZ/123,456/stations').reply(200, {
+      features: [{ id: 'stationPrecip' }]
+    });
+
+    const precipData = {
+      properties: {
+        dewpoint: { value: 10, unitCode: 'wmoUnit:degC' },
+        relativeHumidity: { value: 80 },
+        temperature: { value: 20, unitCode: 'wmoUnit:degC' },
+        icon: 'https://api.weather.gov/icons/land/day/skc?size=medium',
+        textDescription: 'Clear',
+        precipitationLastHour: { value: 12.5, unitCode: 'wmoUnit:mm' },
+        probabilityOfPrecipitation: { value: 85, unitCode: 'wmoUnit:percent' },
+      }
+    };
+    mock.onGet('stationPrecip/observations/latest').reply(200, precipData);
+
+    const weatherData = await provider.getWeather(latInUS, lngInUS);
+
+    expect(weatherData.precipitationRate).toEqual({
+      value: 12.5,
+      unit: 'mm/h'
+    });
+    expect(weatherData.precipitationProbability).toEqual({
+      value: 85,
+      unit: 'percent'
     });
   });
 
@@ -493,6 +528,8 @@ describe('NWSProvider', () => {
       windSpeed: { value: 15, unit: 'm/s' },
       windGust: { value: 20, unit: 'm/s' },
       windDirection: { value: 180, unit: 'degrees' },
+      precipitationRate: { value: 10, unit: 'mm/h' },
+      precipitationProbability: { value: 40, unit: 'percent' },
     });
   });
 

--- a/src/providers/nws/client.ts
+++ b/src/providers/nws/client.ts
@@ -269,6 +269,23 @@ function convertToWeatherData(
     };
   }
 
+  const precipRateValue = properties.precipitationLastHour?.value;
+  if (typeof precipRateValue === 'number') {
+    // NWS precipitation relies on mm since their wmoUnit expects metric base types generally
+    result.precipitationRate = {
+      value: precipRateValue,
+      unit: IWeatherUnits.mmh, // we map 1h accumulator to mmh rate natively
+    };
+  }
+
+  const popValue = properties.probabilityOfPrecipitation?.value;
+  if (typeof popValue === 'number') {
+    result.precipitationProbability = {
+      value: popValue,
+      unit: IWeatherUnits.percent,
+    };
+  }
+
   return result;
 }
 

--- a/src/providers/nws/interfaces.ts
+++ b/src/providers/nws/interfaces.ts
@@ -274,6 +274,14 @@ export interface IObservationsLatest {
       value: number | null;
       unitCode: string;
     };
+    precipitationLastHour?: {
+      value: number | null;
+      unitCode: string;
+    };
+    probabilityOfPrecipitation?: {
+      value: number | null;
+      unitCode: string;
+    };
     icon: string;
     textDescription: string;
     // Include other fields as necessary

--- a/src/providers/openweather/client.test.ts
+++ b/src/providers/openweather/client.test.ts
@@ -32,6 +32,7 @@ describe('OpenWeatherProvider', () => {
         wind_speed: 15,
         wind_gust: 22,
         wind_deg: 180,
+        rain: { '1h': 2.5 },
         weather: [
           {
             id: 800,
@@ -88,7 +89,104 @@ describe('OpenWeatherProvider', () => {
       windDirection: {
         value: 180,
         unit: 'degrees'
+      },
+      precipitationRate: {
+        value: 2.5,
+        unit: 'mm/h'
       }
+    });
+  });
+
+  it('should extract snow precipitation rate when rain is undefined', async () => {
+    const mockResponse = {
+      current: {
+        dew_point: 10,
+        humidity: 80,
+        temp: 20,
+        clouds: 25,
+        sunrise: 1743158735,
+        sunset: 1743202975,
+        snow: { '1h': 4.2 },
+        weather: [
+          {
+            id: 800,
+            main: 'Clear',
+            description: 'clear sky',
+            icon: '01d',
+          },
+        ],
+      },
+    };
+
+    mock.onGet('https://api.openweathermap.org/data/3.0/onecall').reply(200, mockResponse);
+    const weatherData = await provider.getWeather(lat, lng);
+    
+    expect(weatherData.precipitationRate).toEqual({
+      value: 4.2,
+      unit: 'mm/h'
+    });
+  });
+
+  it('should set precipitation rate to 0 when neither rain nor snow is present', async () => {
+    const mockResponse = {
+      current: {
+        dew_point: 10,
+        humidity: 80,
+        temp: 20,
+        clouds: 25,
+        sunrise: 1743158735,
+        sunset: 1743202975,
+        weather: [
+          {
+            id: 800,
+            main: 'Clear',
+            description: 'clear sky',
+            icon: '01d',
+          },
+        ],
+      },
+    };
+
+    mock.onGet('https://api.openweathermap.org/data/3.0/onecall').reply(200, mockResponse);
+    const weatherData = await provider.getWeather(lat, lng);
+    
+    expect(weatherData.precipitationRate).toEqual({
+      value: 0,
+      unit: 'mm/h'
+    });
+  });
+
+  it('should extract POP from hourly forecast when available', async () => {
+    const mockResponse = {
+      current: {
+        dew_point: 10,
+        humidity: 80,
+        temp: 20,
+        clouds: 25,
+        sunrise: 1743158735,
+        sunset: 1743202975,
+        weather: [
+          {
+            id: 800,
+            main: 'Clear',
+            description: 'clear sky',
+            icon: '01d',
+          },
+        ],
+      },
+      hourly: [
+        {
+          pop: 0.65
+        }
+      ]
+    };
+
+    mock.onGet('https://api.openweathermap.org/data/3.0/onecall').reply(200, mockResponse);
+    const weatherData = await provider.getWeather(lat, lng);
+    
+    expect(weatherData.precipitationProbability).toEqual({
+      value: 65,
+      unit: 'percent'
     });
   });
 

--- a/src/providers/openweather/client.ts
+++ b/src/providers/openweather/client.ts
@@ -122,5 +122,36 @@ function convertToWeatherData(data: IOpenWeatherResponse): Partial<IWeatherProvi
     };
   }
 
+  // OpenWeather returns precipitation values conditionally
+  // current.rain.1h and current.snow.1h are mm/h
+  if (data.current.rain?.['1h'] !== undefined) {
+    result.precipitationRate = {
+      value: data.current.rain['1h'],
+      unit: IWeatherUnits.mmh,
+    };
+  } else if (data.current.snow?.['1h'] !== undefined) {
+    result.precipitationRate = {
+      value: data.current.snow['1h'],
+      unit: IWeatherUnits.mmh,
+    };
+  } else {
+    // If no rain or snow block is present, it's 0 mm/h
+    result.precipitationRate = {
+      value: 0,
+      unit: IWeatherUnits.mmh,
+    };
+  }
+
+  // OpenWeather only provides POP on MINUTELY/HOURLY/DAILY forecasts, not current
+  // In the real-time endpoint, we can't reliably populate precipitationProbability
+  // without digging into the first element of hourly/minutely, which we only do
+  // if hourly[] exists.
+  if (data.hourly && data.hourly.length > 0 && typeof data.hourly[0].pop === 'number') {
+    result.precipitationProbability = {
+      value: data.hourly[0].pop * 100, // API returns 0 to 1, convert to %
+      unit: IWeatherUnits.percent,
+    };
+  }
+
   return result;
 }

--- a/src/providers/openweather/interfaces.ts
+++ b/src/providers/openweather/interfaces.ts
@@ -18,6 +18,8 @@ export interface IOpenWeatherResponse {
     wind_speed: number;
     wind_deg: number;
     wind_gust?: number;
+    rain?: { '1h'?: number };
+    snow?: { '1h'?: number };
     weather: {
       id: number;
       main: string;
@@ -25,5 +27,8 @@ export interface IOpenWeatherResponse {
       icon: string;
     }[];
   };
+  hourly?: {
+    pop?: number;
+  }[];
   // Include additional fields if required
 }

--- a/src/providers/tomorrow/client.test.ts
+++ b/src/providers/tomorrow/client.test.ts
@@ -38,6 +38,8 @@ describe('TomorrowProvider', () => {
           windSpeed: 4.5,
           windGust: 7.2,
           windDirection: 180,
+          precipitationIntensity: 1.5,
+          precipitationProbability: 60,
         },
       },
       location: {
@@ -66,7 +68,37 @@ describe('TomorrowProvider', () => {
       windSpeed: { value: 4.5, unit: 'm/s' },
       windGust: { value: 7.2, unit: 'm/s' },
       windDirection: { value: 180, unit: 'degrees' },
+      precipitationRate: { value: 1.5, unit: 'mm/h' },
+      precipitationProbability: { value: 60, unit: 'percent' },
     });
+  });
+
+  it('should extract precipitation metrics when provided', async () => {
+    const mockResponse = {
+      data: {
+        time: '2023-01-26T07:48:00Z',
+        values: {
+          cloudCover: 100,
+          dewPoint: 0.88,
+          humidity: 96,
+          temperature: 1.88,
+          weatherCode: 1001,
+          precipitationIntensity: 1.5,
+          precipitationProbability: 60,
+        },
+      },
+      location: {
+        lat,
+        lon: lng,
+      },
+    };
+
+    mock.onGet('https://api.tomorrow.io/v4/weather/realtime').reply(200, mockResponse);
+
+    const data = await provider.getWeather(lat, lng);
+
+    expect(data.precipitationRate).toEqual({ value: 1.5, unit: 'mm/h' });
+    expect(data.precipitationProbability).toEqual({ value: 60, unit: 'percent' });
   });
 
   it('normalizes unknown or missing weather codes into descriptive strings', async () => {

--- a/src/providers/tomorrow/client.ts
+++ b/src/providers/tomorrow/client.ts
@@ -65,7 +65,7 @@ function convertToWeatherData(payload: ITomorrowRealtimeResponse): Partial<IWeat
     throw new Error('Invalid weather data');
   }
 
-  const { temperature, humidity, dewPoint, cloudCover, weatherCode, windSpeed, windGust, windDirection } = values;
+  const { temperature, humidity, dewPoint, cloudCover, weatherCode, windSpeed, windGust, windDirection, precipitationIntensity, precipitationProbability } = values;
 
   if (
     typeof temperature !== 'number' &&
@@ -123,6 +123,20 @@ function convertToWeatherData(payload: ITomorrowRealtimeResponse): Partial<IWeat
     result.windDirection = {
       value: windDirection,
       unit: IWeatherUnits.degrees,
+    };
+  }
+
+  if (typeof precipitationIntensity === 'number') {
+    result.precipitationRate = {
+      value: precipitationIntensity,
+      unit: IWeatherUnits.mmh,
+    };
+  }
+
+  if (typeof precipitationProbability === 'number') {
+    result.precipitationProbability = {
+      value: precipitationProbability,
+      unit: IWeatherUnits.percent,
     };
   }
 

--- a/src/providers/tomorrow/interfaces.ts
+++ b/src/providers/tomorrow/interfaces.ts
@@ -10,6 +10,8 @@ export interface ITomorrowRealtimeResponse {
       windSpeed?: number;
       windGust?: number;
       windDirection?: number;
+      precipitationIntensity?: number;
+      precipitationProbability?: number;
     };
   };
   location?: {

--- a/src/providers/weatherbit/client.test.ts
+++ b/src/providers/weatherbit/client.test.ts
@@ -40,6 +40,8 @@ describe('WeatherbitProvider', () => {
           wind_spd: 4.5,
           wind_dir: 180,
           gust: 7.2,
+          precip: 2.5,
+          pop: 80,
           },
       ],
     };
@@ -65,7 +67,33 @@ describe('WeatherbitProvider', () => {
       windSpeed: { value: 4.5, unit: 'm/s' },
       windGust: { value: 7.2, unit: 'm/s' },
       windDirection: { value: 180, unit: 'degrees' },
+      precipitationRate: { value: 2.5, unit: 'mm/h' },
+      precipitationProbability: { value: 80, unit: 'percent' },
     });
+  });
+
+  it('should extract precipitation metrics when provided', async () => {
+    const mockResponse = {
+      data: [
+        {
+          dewpt: 0.88,
+          rh: 96,
+          temp: 1.88,
+          weather: {
+            code: 804,
+          },
+          precip: 2.5,
+          pop: 80,
+        },
+      ],
+    };
+
+    mock.onGet('https://api.weatherbit.io/v2.0/current').reply(200, mockResponse);
+
+    const data = await provider.getWeather(lat, lng);
+
+    expect(data.precipitationRate).toEqual({ value: 2.5, unit: 'mm/h' });
+    expect(data.precipitationProbability).toEqual({ value: 80, unit: 'percent' });
   });
 
   it('records failure metadata when Weatherbit responds with an error', async () => {

--- a/src/providers/weatherbit/client.ts
+++ b/src/providers/weatherbit/client.ts
@@ -66,7 +66,7 @@ function convertToWeatherData(payload: IWeatherbitCurrentResponse): Partial<IWea
     throw new Error('Invalid weather data');
   }
 
-  const { temp, rh, dewpt, clouds, weather, wind_spd, wind_dir, gust } = current;
+  const { temp, rh, dewpt, clouds, weather, wind_spd, wind_dir, gust, precip, pop } = current;
 
   if (
     typeof temp !== 'number' &&
@@ -124,6 +124,20 @@ function convertToWeatherData(payload: IWeatherbitCurrentResponse): Partial<IWea
     result.windGust = {
       value: gust,
       unit: IWeatherUnits.mps,
+    };
+  }
+
+  if (typeof precip === 'number') {
+    result.precipitationRate = {
+      value: precip,
+      unit: IWeatherUnits.mmh,
+    };
+  }
+
+  if (typeof pop === 'number') {
+    result.precipitationProbability = {
+      value: pop,
+      unit: IWeatherUnits.percent,
     };
   }
 

--- a/src/providers/weatherbit/interfaces.ts
+++ b/src/providers/weatherbit/interfaces.ts
@@ -7,6 +7,8 @@ export interface IWeatherbitCurrentResponse {
     wind_spd?: number; // Wind speed in m/s
     wind_dir?: number; // Wind direction in degrees
     gust?: number; // Wind gust in m/s
+    precip?: number; // Liquid equivalent precipitation rate (mm/hr)
+    pop?: number; // Probability of precipitation (%)
     weather?: {
       code?: number;
       description?: string;


### PR DESCRIPTION
Resolves https://linear.app/texture/issue/CIR-1089/feature-add-precipitation-properties-to-iweatherdata

This PR introduces `precipitationRate` (intensity, handled in `mm/h`) and `precipitationProbability` (in `percent`) to the core interface to unblock fleet routing logistics use-cases.

Extracted natively from NWS, Tomorrow.io, Weatherbit, and OpenWeather (via Realtime conditions and the current hourly forecast block where applicable).